### PR TITLE
Refactor startup/shutdown to FastAPI lifespan

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import logging
 from fastapi import FastAPI, Depends
 from fastapi.middleware.cors import CORSMiddleware
+from contextlib import asynccontextmanager
 
 from .core.config import settings
 from .core.logging import setup_logging
@@ -14,7 +15,46 @@ from .deps import auth_dep
 setup_logging(to_console=True)
 log = logging.getLogger("amadeus.main")
 
-app = FastAPI(title="Amadeus Backend", version="1.0")
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    """Manage application startup and shutdown events."""
+    try:
+        settings.load_yaml()
+    except Exception as e:
+        log.exception("Failed to load configuration: %s", e)
+        raise
+
+    state = await get_state()
+    state.cfg = settings.runtime_cfg or {}
+    log.info(
+        "Config синхронизирован: ui.chart=%s, api.paper=%s, api.shadow=%s, api.autostart=%s",
+        state.cfg.get("ui", {}).get("chart"),
+        state.cfg.get("api", {}).get("paper"),
+        state.cfg.get("api", {}).get("shadow"),
+        state.cfg.get("api", {}).get("autostart"),
+    )
+
+    autostart = bool(state.cfg.get("api", {}).get("autostart", False))
+    if autostart:
+        log.warning("autostart=true — запускаю бота по конфигу…")
+        try:
+            await state.start_bot()
+            log.info("Бот запущен (autostart).")
+        except Exception as e:
+            log.exception("Не удалось автозапустить бота: %s", e)
+
+    yield
+
+    state = await get_state()
+    try:
+        if state.is_running():
+            await state.stop_bot()
+            log.info("Бот остановлен на shutdown.")
+    except Exception:
+        log.exception("Ошибка остановки бота на shutdown")
+
+
+app = FastAPI(title="Amadeus Backend", version="1.0", lifespan=lifespan)
 
 # ---- CORS ----
 origins = [o.strip() for o in (settings.app_origins or "http://127.0.0.1:4400,http://localhost:4400").split(",") if o.strip()]
@@ -55,46 +95,6 @@ except Exception as e:
 # ---- WebSocket (/ws) ----
 from .api.routers import ws as ws_router
 app.include_router(ws_router.router)  # путь /ws
-
-# ---- Старт/стоп хуки ----
-@app.on_event("startup")
-async def on_startup():
-    """Load runtime configuration and optionally start the bot."""
-    try:
-        settings.load_yaml()
-    except Exception as e:
-        log.exception("Failed to load configuration: %s", e)
-        raise
-
-    state = await get_state()
-    state.cfg = settings.runtime_cfg or {}
-    log.info(
-        "Config синхронизирован: ui.chart=%s, api.paper=%s, api.shadow=%s, api.autostart=%s",
-        state.cfg.get("ui", {}).get("chart"),
-        state.cfg.get("api", {}).get("paper"),
-        state.cfg.get("api", {}).get("shadow"),
-        state.cfg.get("api", {}).get("autostart"),
-    )
-
-    # НЕ автозапуск по умолчанию
-    autostart = bool(state.cfg.get("api", {}).get("autostart", False))
-    if autostart:
-        log.warning("autostart=true — запускаю бота по конфигу…")
-        try:
-            await state.start_bot()
-            log.info("Бот запущен (autostart).")
-        except Exception as e:
-            log.exception("Не удалось автозапустить бота: %s", e)
-
-@app.on_event("shutdown")
-async def on_shutdown():
-    state = await get_state()
-    try:
-        if state.is_running():
-            await state.stop_bot()
-            log.info("Бот остановлен на shutdown.")
-    except Exception:
-        log.exception("Ошибка остановки бота на shutdown")
 
 # ---- Root ----
 @app.get("/")


### PR DESCRIPTION
## Summary
- replace startup and shutdown events with an async lifespan handler
- wire FastAPI to use the lifespan context

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b8b8fe6628832d89db6734676b3874