### PR TITLE
feat: configure api service environment

### DIFF
--- a/frontend/src/app/services/api.service.ts
+++ b/frontend/src/app/services/api.service.ts
@@ -23,7 +23,7 @@ export class ApiService {
   private readonly win = window as unknown as { __API__?: string; __TOKEN__?: string };
   private readonly baseRoot: string = (this.win.__API__ || environment.apiBaseUrl || 'http://127.0.0.1:8100').replace(/\/$/, '');
   readonly api: string = this.baseRoot + '/api';
-  private readonly _token: string = this.win.__TOKEN__ || 'b1a7528e92de0ce1e456b7afad435b47ce870dcb41688de2af9e815a5a65372c';
+  private readonly _token: string = this.win.__TOKEN__ || environment.token || 'b1a7528e92de0ce1e456b7afad435b47ce870dcb41688de2af9e815a5a65372c';
 
   private auth() { return { headers: { 'Authorization': `Bearer ${this._token}` } }; }
   get token(): string { return this._token; }

--- a/frontend/src/environments/environment.ts
+++ b/frontend/src/environments/environment.ts
@@ -1,5 +1,4 @@
 export const environment = {
-
-  apiBaseUrl: 'http://127.0.0.1:8100'
-
+  apiBaseUrl: 'http://127.0.0.1:8100',
+  token: ''
 };

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,8 +1,11 @@
 import { enableProdMode } from '@angular/core';
 import { bootstrapApplication } from '@angular/platform-browser';
 import { provideRouter } from '@angular/router';
+import { provideHttpClient } from '@angular/common/http';
 import { AppComponent } from './app/app.component';
 import { routes } from './app/app.routes';
 
-bootstrapApplication(AppComponent, { providers: [provideRouter(routes)] })
+bootstrapApplication(AppComponent, {
+  providers: [provideRouter(routes), provideHttpClient()]
+})
   .catch(err => console.error(err));


### PR DESCRIPTION
## Summary
- provide HttpClient at bootstrap level for app
- add API base URL and token to environment
- read base URL and token from environment in ApiService

## Testing
- `npm run build` *(fails: A builder is not set for target 'build' in project 'amadeus-mvp-ui')*

------
https://chatgpt.com/codex/tasks/task_e_68b8f867dab8832db7049a807e9fb6e3