### PR TITLE
refactor(frontend): use ApiService in dashboard and strategies

### DIFF
--- a/frontend/src/app/pages/dashboard.component.ts
+++ b/frontend/src/app/pages/dashboard.component.ts
@@ -1,4 +1,5 @@
-import { Component, signal, effect } from '@angular/core';
+import { Component, signal } from '@angular/core';
+import { ApiService } from '../services/api.service';
 
 @Component({
   standalone: true,
@@ -14,9 +15,12 @@ import { Component, signal, effect } from '@angular/core';
 })
 export class DashboardComponent {
   status = signal<any>({});
-  async ngOnInit(){ await this.refresh(); }
-  async refresh(){
-    const res = await fetch('http://localhost:8100/api/status');
-    this.status.set(await res.json());
+
+  constructor(private api: ApiService) {
+    this.refresh();
+  }
+
+  refresh() {
+    this.api.status().subscribe(res => this.status.set(res));
   }
 }

--- a/frontend/src/app/pages/strategies.component.ts
+++ b/frontend/src/app/pages/strategies.component.ts
@@ -1,4 +1,5 @@
 import { Component } from '@angular/core';
+import { ApiService } from '../services/api.service';
 
 @Component({
   standalone: true,
@@ -10,13 +11,17 @@ import { Component } from '@angular/core';
   `
 })
 export class StrategiesComponent {
-  async start(){
-    await fetch('http://localhost:8100/api/bot/start', {
-      method: 'POST', headers: {'Content-Type':'application/json'},
-      body: JSON.stringify({strategy:'sample_ema', config:{symbol:'BTCUSDT', tf:'1m', fast:9, slow:21, qty:0.001}})
-    });
+  constructor(private api: ApiService) {}
+
+  start() {
+    const body = {
+      strategy: 'sample_ema',
+      config: { symbol: 'BTCUSDT', tf: '1m', fast: 9, slow: 21, qty: 0.001 }
+    };
+    this.api.start(body).subscribe();
   }
-  async stop(){
-    await fetch('http://localhost:8100/api/bot/stop', {method:'POST'});
+
+  stop() {
+    this.api.stop().subscribe();
   }
 }

--- a/frontend/src/app/services/api.service.ts
+++ b/frontend/src/app/services/api.service.ts
@@ -44,7 +44,9 @@ export class ApiService {
 
   // ------------ BOT ------------
   status(): Observable<BotStatus> { return this.http.get<BotStatus>(`${this.api}/bot/status`, this.auth()); }
-  start():  Observable<unknown>   { return this.http.post(`${this.api}/bot/start`, {}, this.auth()); }
+  start(body: unknown = {}): Observable<unknown> {
+    return this.http.post(`${this.api}/bot/start`, body ?? {}, this.auth());
+  }
   stop():   Observable<unknown>   { return this.http.post(`${this.api}/bot/stop`,  {}, this.auth()); }
   cmd(command: string, save = false): Observable<BotStatus> {
     const q = save ? '?save=1' : '';


### PR DESCRIPTION
## Summary
- use ApiService instead of direct fetch in dashboard and strategies pages
- extend ApiService.start to accept optional payload

## Testing
- `pytest` *(fails: ImportError: cannot import name 'get_state')*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b8fa96580c832dafc778a9473e13ab