### PR TITLE
Add service name to root endpoint response

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -23,4 +23,8 @@ app.include_router(ws.router)  # /ws
 
 @app.get("/")
 def root():
-    return {"ok": True, "service": "amadeus-mvp"}
+    return {
+        "ok": True,
+        "service": "amadeus-mvp",
+        "name": "Amadeus Multi-Exchange MVP",
+    }


### PR DESCRIPTION
## Summary
- include a human-friendly service name field in `/` response

## Testing
- `pytest` (fails: ImportError: cannot import name 'get_state')

------
https://chatgpt.com/codex/tasks/task_e_68b91b575d40832dbdd12c1347d6326d