### PR TITLE
Fix duplicate asyncio import in panic sell test

### DIFF
--- a/tests/test_panic_sell.py
+++ b/tests/test_panic_sell.py
@@ -1,7 +1,5 @@
 import asyncio
 
-import asyncio
-
 from backend.app.services.state import AppState
 from backend.app.services.risk.manager import RiskManager
 


### PR DESCRIPTION
## Summary
- remove redundant asyncio import from panic sell test

## Testing
- `PYTHONPATH=. pytest --noconftest tests/test_panic_sell.py` *(fails: AttributeError: 'AppState' object has no attribute 'panic_sell')*

------
https://chatgpt.com/codex/tasks/task_e_68b91ba7aa8c832d985b0baf773dcd10