### PR TITLE
fix: add missing space in strategies link

### DIFF
--- a/frontend/src/app/shell/app-shell.component.ts
+++ b/frontend/src/app/shell/app-shell.component.ts
@@ -15,7 +15,7 @@ import { RouterLink, RouterOutlet } from '@angular/router';
       <nav class="flex flex-col gap-1">
         <a routerLink="/dashboard" routerLinkActive="bg-[#151a20]" class="flex items-center gap-3 px-3 py-2 rounded-xl hover:bg-[#141820]">🏠 <span *ngIf="!collapsed">Dashboard</span></a>
         <a routerLink="/market"    routerLinkActive="bg-[#151a20]" class="flex items-center gap-3 px-3 py-2 rounded-xl hover:bg-[#141820]">📈 <span *ngIf="!collapsed">Market</span></a>
-        <a routerLink="/strategies"routerLinkActive="bg-[#151a20]" class="flex items-center gap-3 px-3 py-2 rounded-xl hover:bg-[#141820]">🤖 <span *ngIf="!collapsed">Strategies</span></a>
+        <a routerLink="/strategies" routerLinkActive="bg-[#151a20]" class="flex items-center gap-3 px-3 py-2 rounded-xl hover:bg-[#141820]">🤖 <span *ngIf="!collapsed">Strategies</span></a>
       </nav>
     </aside>
 


### PR DESCRIPTION
## Summary
- fix missing space between routerLink and routerLinkActive in strategies navigation link

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b942dccb1c832db29e1da7b4946269