### PR TITLE
Configure Angular to compile SCSS

### DIFF
--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -16,7 +16,7 @@
             "main": "src/main.ts",
             "tsConfig": "tsconfig.app.json",
             "assets": ["src/favicon.ico","src/assets"],
-            "styles": ["src/styles.css"],
+            "styles": ["src/styles.scss"],
             "scripts": []
           },
           "configurations": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -31,6 +31,7 @@
         "@angular/compiler-cli": "^20.2.4",
         "@tailwindcss/postcss": "^4.1.12",
         "postcss": "^8.5.6",
+        "sass": "^1.92.0",
         "tailwindcss": "^4.1.12",
         "typescript": "~5.9.2"
       }
@@ -420,6 +421,27 @@
         }
       }
     },
+    "node_modules/@angular-devkit/build-angular/node_modules/sass": {
+      "version": "1.90.0",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.90.0.tgz",
+      "integrity": "sha512-9GUyuksjw70uNpb1MTYWsH9MQHOHY6kwfnkafC24+7aOMZn9+rVMBxRbLvw756mrBFbIsFg6Xw9IkR2Fnn3k+Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chokidar": "^4.0.0",
+        "immutable": "^5.0.2",
+        "source-map-js": ">=0.6.2 <2.0.0"
+      },
+      "bin": {
+        "sass": "sass.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "optionalDependencies": {
+        "@parcel/watcher": "^2.4.1"
+      }
+    },
     "node_modules/@angular-devkit/build-webpack": {
       "version": "0.2002.2",
       "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.2002.2.tgz",
@@ -599,6 +621,27 @@
         "vitest": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@angular/build/node_modules/sass": {
+      "version": "1.90.0",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.90.0.tgz",
+      "integrity": "sha512-9GUyuksjw70uNpb1MTYWsH9MQHOHY6kwfnkafC24+7aOMZn9+rVMBxRbLvw756mrBFbIsFg6Xw9IkR2Fnn3k+Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chokidar": "^4.0.0",
+        "immutable": "^5.0.2",
+        "source-map-js": ">=0.6.2 <2.0.0"
+      },
+      "bin": {
+        "sass": "sass.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "optionalDependencies": {
+        "@parcel/watcher": "^2.4.1"
       }
     },
     "node_modules/@angular/cdk": {
@@ -12054,9 +12097,9 @@
       "license": "MIT"
     },
     "node_modules/sass": {
-      "version": "1.90.0",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.90.0.tgz",
-      "integrity": "sha512-9GUyuksjw70uNpb1MTYWsH9MQHOHY6kwfnkafC24+7aOMZn9+rVMBxRbLvw756mrBFbIsFg6Xw9IkR2Fnn3k+Q==",
+      "version": "1.92.0",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.92.0.tgz",
+      "integrity": "sha512-KDNI0BxgIRDAfJgzNm5wuy+4yOCIZyrUbjSpiU/JItfih+KGXAVefKL53MTml054MmBA3DDKIBMSI/7XLxZJ3A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -30,6 +30,7 @@
     "@angular/compiler-cli": "^20.2.4",
     "@tailwindcss/postcss": "^4.1.12",
     "postcss": "^8.5.6",
+    "sass": "^1.92.0",
     "tailwindcss": "^4.1.12",
     "typescript": "~5.9.2"
   }

--- a/frontend/src/_mixins.scss
+++ b/frontend/src/_mixins.scss
@@ -1,13 +1,14 @@
 @use 'variables' as v;
+@use 'sass:map';
 
 @mixin font($size: base, $weight: normal) {
   font-family: v.$font-family-base;
-  font-size: map-get(v.$font-sizes, $size);
+  font-size: map.get(v.$font-sizes, $size);
   font-weight: $weight;
 }
 
 @mixin spacing($property, $size) {
-  #{$property}: map-get(v.$spaces, $size);
+  #{$property}: map.get(v.$spaces, $size);
 }
 
 @mixin icon {

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -1,5 +1,8 @@
-@import "tailwindcss";
 @use 'mixins' as m;
+@use 'variables' as v;
+@use 'sass:meta';
+
+@include meta.load-css('tailwindcss');
 
 html, body {
   height: 100%;


### PR DESCRIPTION
## Summary
- enable Sass processing for the Angular app
- replace deprecated Sass functions and import tailwind via sass:meta

## Testing
- `npm run build`
- `pytest` *(fails: AttributeError: 'AppState' object has no attribute 'panic_sell'...)*

------
https://chatgpt.com/codex/tasks/task_e_68b94afe3078832db2725577f729b442