### PR TITLE
feat: specify base href

### DIFF
--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8">
     <title>Amadeus</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <base href="/">
     <link rel="icon" href="favicon.ico">
     <link rel="preconnect" href="https://rsms.me">
     <link rel="stylesheet" href="https://rsms.me/inter/inter.css">


### PR DESCRIPTION
## Summary
- ensure Angular app uses root-relative URLs by adding base href

## Testing
- `npm run build`
- `pytest` *(fails: AttributeError: 'AppState' object has no attribute 'panic_sell', AttributeError: 'AppState' object has no attribute 'check_risk')*

------
https://chatgpt.com/codex/tasks/task_e_68b94da89054832d95c40235ca20d443