### PR TITLE
Update risk tests for new policy interface

### DIFF
--- a/backend/tests/test_risk.py
+++ b/backend/tests/test_risk.py
@@ -1,16 +1,22 @@
 from backend.core.risk import RiskEngine
 
-def test_risk_forbid_market():
+
+def test_risk_drawdown_limit():
     r = RiskEngine()
-    r.set_limits({"forbid_market_orders": True})
-    class Req: type='market'; qty=1.0; side='buy'
-    d = r.pre_trade_check(req=Req(), open_orders_count=0, current_pos_qty=0.0)
-    assert not d.allowed and 'forbidden' in d.reason
+    r.set_policy("default", max_dd=0.1)
+    d = r.pre_trade_check(
+        strategy_id="default", open_orders_count=0, current_drawdown=0.15
+    )
+    assert not d.allowed and d.reason == "max_dd"
+
 
 def test_risk_active_orders():
     r = RiskEngine()
-    r.set_limits({"max_active_orders": 1})
-    class Req: type='limit'; qty=1.0; side='buy'
-    d_ok = r.pre_trade_check(req=Req(), open_orders_count=0, current_pos_qty=0.0)
-    d_bad = r.pre_trade_check(req=Req(), open_orders_count=1, current_pos_qty=0.0)
-    assert d_ok.allowed and not d_bad.allowed
+    r.set_policy("default", max_active_orders=1)
+    d_ok = r.pre_trade_check(
+        strategy_id="default", open_orders_count=1, current_drawdown=0.0
+    )
+    d_bad = r.pre_trade_check(
+        strategy_id="default", open_orders_count=2, current_drawdown=0.0
+    )
+    assert d_ok.allowed and not d_bad.allowed and d_bad.reason == "max_active_orders"


### PR DESCRIPTION
## Summary
- adapt risk tests to new `set_policy`/`pre_trade_check` API
- check drawdown and active order limits without synthetic request objects

## Testing
- `PYTHONPATH=. pytest backend/tests/test_risk.py`


------
https://chatgpt.com/codex/tasks/task_e_68b951a76b20832d9f580b88e55c9f7e