### PR TITLE
Add EMA crossover tick and book handling

### DIFF
--- a/backend/plugins/sample_ema_crossover.py
+++ b/backend/plugins/sample_ema_crossover.py
@@ -34,28 +34,49 @@ class SampleEmaCrossover(StrategyPlugin):
 
     async def on_start(self) -> None:
         self.ctx.logger.info(f"[ema] start {self.cfg}")
-        # подписка на трейды
+        # subscribe to market data streams
         await self.ctx.md.subscribe_trades(self.cfg["symbol"], self.on_trade)
+        subscribe_book = getattr(self.ctx.md, "subscribe_book", None)
+        if callable(subscribe_book):
+            await subscribe_book(self.cfg["symbol"], "L2", self.on_book)
 
     async def on_stop(self) -> None:
         self.ctx.logger.info("[ema] stop")
 
     async def on_tick(self, symbol: str) -> None:
-        pass
+        # periodically evaluate EMA crossover using cached prices
+        await self._evaluate()
 
     async def on_book(self, msg) -> None:
-        pass
+        # use mid price of top of book as a price input
+        price = None
+        if msg.bids and msg.asks:
+            price = (msg.bids[0].price + msg.asks[0].price) / 2
+        elif msg.bids:
+            price = msg.bids[0].price
+        elif msg.asks:
+            price = msg.asks[0].price
+        if price is not None:
+            self.prices.append(price)
+            self._trim_prices()
+        await self._evaluate()
 
     async def on_trade(self, msg) -> None:
         self.prices.append(msg.price)
+        self._trim_prices()
+        await self._evaluate()
+
+    def _trim_prices(self) -> None:
         maxlen = max(self.cfg["short"], self.cfg["long"]) * 4
         if len(self.prices) > maxlen:
             self.prices = self.prices[-maxlen:]
+
+    async def _evaluate(self) -> None:
         if len(self.prices) < self.cfg["long"] + 2:
             return
         s = ema(self.prices[-self.cfg["short"]:], self.cfg["short"])
         l = ema(self.prices[-self.cfg["long"]:], self.cfg["long"])
         if s > l:
-            await self.ctx.trader.place_order({"symbol": self.cfg["symbol"], "side":"buy", "qty": self.cfg["qty"]})
+            await self.ctx.trader.place_order({"symbol": self.cfg["symbol"], "side": "buy", "qty": self.cfg["qty"]})
         elif s < l:
-            await self.ctx.trader.place_order({"symbol": self.cfg["symbol"], "side":"sell", "qty": self.cfg["qty"]})
+            await self.ctx.trader.place_order({"symbol": self.cfg["symbol"], "side": "sell", "qty": self.cfg["qty"]})


### PR DESCRIPTION
## Summary
- subscribe to book updates and evaluate EMA crossovers using cached prices
- track order book mid price and trigger trades on tick/book events

## Testing
- `pytest` *(fails: AttributeError: 'AppState' object has no attribute 'check_risk' / 'panic_sell')*

------
https://chatgpt.com/codex/tasks/task_e_68b9548f30cc832d8044795202e41630