### PR TITLE
Await async unsubscribe callbacks in market websockets

### DIFF
--- a/backend/api/routers/market.py
+++ b/backend/api/routers/market.py
@@ -1,3 +1,4 @@
+import inspect
 from fastapi import APIRouter, Depends, WebSocket, WebSocketDisconnect, Query
 from backend.api.deps import require_token
 from backend.adapters.registry import get_adapter
@@ -24,7 +25,13 @@ async def ws_book(ws: WebSocket, exchange: str = Query("mock"), category: str = 
     except WebSocketDisconnect:
         pass
     finally:
-        if unsub: unsub()
+        if unsub:
+            if inspect.iscoroutinefunction(unsub):
+                await unsub()
+            else:
+                result = unsub()
+                if inspect.iscoroutine(result):
+                    await result
 
 @router.websocket("/ws/trades")
 async def ws_trades(ws: WebSocket, exchange: str = Query("mock"), category: str = Query("spot"), symbol: str = Query(...)):
@@ -40,4 +47,10 @@ async def ws_trades(ws: WebSocket, exchange: str = Query("mock"), category: str 
     except WebSocketDisconnect:
         pass
     finally:
-        if unsub: unsub()
+        if unsub:
+            if inspect.iscoroutinefunction(unsub):
+                await unsub()
+            else:
+                result = unsub()
+                if inspect.iscoroutine(result):
+                    await result


### PR DESCRIPTION
## Summary
- await unsubscribe callbacks in `ws_book` and `ws_trades` when they are coroutines
- import `inspect` and handle coroutine results for clean websocket closure

## Testing
- `pytest -q` *(fails: AttributeError: 'AppState' object has no attribute 'panic_sell')*


------
https://chatgpt.com/codex/tasks/task_e_68b95572153c832d82570eefca48acf1