### PR TITLE
Add PrimeNG Aura theme import to global styles

### DIFF
--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -3,6 +3,7 @@
 
 /* PrimeIcons */
 @import 'primeicons/primeicons.css';
+@import '@primeng/themes/aura/theme.css';
 
 /* AG Grid Quartz */
 @import 'ag-grid-community/styles/ag-grid.css';


### PR DESCRIPTION
## Summary
- import PrimeNG Aura theme in global styles to enable Aura theming

## Testing
- `npm run build` *(fails: Workspace config file cannot be loaded: Invalid format version detected - Expected: [ 1 ] Found: [ 2 ])*

------
https://chatgpt.com/codex/tasks/task_e_68ba20f60bd4832d8713da498afec6eb