### PR TITLE
Fix Angular workspace version for CLI compatibility

### DIFF
--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -1,15 +1,15 @@
 {
   "$schema": "./node_modules/@angular/cli/lib/config/schema.json",
-  "version": 2,
+  "version": 1,
   "projects": {
     "amadeus-mvp-ui": {
       "projectType": "application",
       "root": "",
       "sourceRoot": "src",
       "prefix": "app",
-      "targets": {
+      "architect": {
         "build": {
-          "executor": "@angular-devkit/build-angular:browser-esbuild",
+          "builder": "@angular-devkit/build-angular:browser-esbuild",
           "options": {
             "outputPath": "dist",
             "index": "src/index.html",
@@ -31,7 +31,7 @@
           "defaultConfiguration": "development"
         },
         "serve": {
-          "executor": "@angular-devkit/build-angular:dev-server",
+          "builder": "@angular-devkit/build-angular:dev-server",
           "options": {
             "buildTarget": "amadeus-mvp-ui:build",
             "host": "127.0.0.1",


### PR DESCRIPTION
## Summary
- ensure Angular workspace uses version 1 with architect/builder syntax for CLI compatibility

## Testing
- `jq '.' angular.json`
- `npx ng serve amadeus-mvp-ui` *(fails: Can't resolve '@primeng/themes/aura/theme.css')*


------
https://chatgpt.com/codex/tasks/task_e_68ba22fc4568832db4b8b04696dffff6