### PR TITLE
fix: use PrimeNG theme subpath

### DIFF
--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -1,7 +1,7 @@
 
 @use 'styles/themes/_tokens';
 
-@import '@primeng/themes/aura/theme.css';
+@import '@primeng/themes/aura';
 
 /* PrimeIcons */
 @import 'primeicons/primeicons.css';


### PR DESCRIPTION
## Summary
- use the exported `@primeng/themes/aura` subpath instead of importing theme.css directly

## Testing
- `npm run build` *(fails: Could not resolve "@primeng/themes/aura"; TS2307: Cannot find module '@primeng/themes/aura')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'pydantic_settings')*


------
https://chatgpt.com/codex/tasks/task_e_68ba28744588832dbd7a24413e9f9456