### PR TITLE
Disable frontend demo mode by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ All API and WebSocket endpoints require a static bearer token.
 
 2. **Frontend** – expose the same token to the browser via `window.__TOKEN__` (and optionally `window.__WS__` for a custom WebSocket URL). The API base URL is configured in `src/environments/environment.ts`. The Angular `ApiService` automatically sends the token in the `Authorization: Bearer` header and the `WsService` appends it as a `token` query parameter.
 
+   Demo mode is disabled by default. To run the UI with sample data, set `demo: true` in `frontend/src/environments/environment.ts` and rebuild the frontend.
+
 3. **Making requests** – clients must include the token:
    - HTTP: `Authorization: Bearer <token>`
    - WebSocket: connect to `/ws?token=<token>`

--- a/frontend/src/environments/environment.ts
+++ b/frontend/src/environments/environment.ts
@@ -1,6 +1,6 @@
 export const environment = {
   production: false,
-  demo: true,
+  demo: false,
   api: 'http://127.0.0.1:8100',
   ws:  'ws://127.0.0.1:8100/ws',
   token: ''


### PR DESCRIPTION
## Summary
- Set `demo` flag to `false` in development environment configuration
- Document how to enable demo mode from `frontend/src/environments/environment.ts`

## Testing
- `npm run build` *(fails: Could not resolve "@primeuix/themes/aura" and related styles)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'pydantic_settings')*

------
https://chatgpt.com/codex/tasks/task_e_68ba6c0e9184832d9441fdbac9c914b3