### PR TITLE
Add pydantic-settings dependency

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,6 +1,7 @@
 fastapi>=0.111.0
 uvicorn[standard]>=0.30.0
 pydantic>=2.8.0
+pydantic-settings>=2.0
 sqlalchemy>=2.0.0
 sqlmodel>=0.0.18
 psycopg2-binary>=2.9.9


### PR DESCRIPTION
## Summary
- include `pydantic-settings>=2.0` in backend requirements so tests can import `pydantic_settings`

## Testing
- `pip show pydantic-settings`
- `pytest` *(fails: AttributeError in panic sell tests)*

------
https://chatgpt.com/codex/tasks/task_e_68ba762a9124832dae0475f9d3ee94ff