### PR TITLE
Implement panic sell and risk checks

### DIFF
--- a/backend/app/services/state.py
+++ b/backend/app/services/state.py
@@ -1,5 +1,5 @@
 import asyncio, time
-from typing import Optional, Dict, Any, Callable
+from typing import Optional, Dict, Any, Callable, Tuple
 from ..core.config import settings
 from .ws import ws_broadcast
 from .history import history
@@ -19,6 +19,8 @@ class AppState:
         self.strategy: Optional[StrategyPlugin] = None
         self._task: Optional[asyncio.Task] = None
         self.mode = settings.mode
+        # risk manager is optional and may be configured in tests
+        self.risk_manager = None
         self._registry: Dict[str, Callable[[], StrategyPlugin]] = {
             "sample_ema": lambda: SampleEMAStrategy(),
         }
@@ -86,6 +88,56 @@ class AppState:
         await ws_broadcast.broadcast({"type": "diag", "text": "Strategy stopped"})
         self.strategy = None
         self.adapter = None
+
+    async def panic_sell(self):
+        """Cancel open orders and liquidate all non-USDT assets."""
+        # Cancel all open orders for the current strategy
+        if getattr(self, "strategy", None) and getattr(self.strategy, "orders", None):
+            for order in list(self.strategy.orders.values()):
+                try:
+                    await self.binance.cancel_order(self.strategy.symbol, order.id)
+                except Exception:
+                    pass
+
+        # Market sell all balances except USDT
+        balances = {}
+        try:
+            balances = await self.binance.get_balances()
+        except Exception:
+            pass
+        for asset, qty in balances.items():
+            if asset == "USDT" or qty == 0:
+                continue
+            symbol = f"{asset}USDT"
+            try:
+                await self.binance.create_market_sell(symbol, qty)
+            except Exception:
+                pass
+
+        # Stop the main running task if any
+        if self._task and not self._task.done():
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+            except Exception:
+                pass
+            self._task = None
+        self.started = False
+
+    def is_running(self) -> bool:
+        """Return ``True`` if the main loop task is running."""
+        return self._task is not None and not self._task.done()
+
+    def check_risk(self, symbol: Optional[str] = None) -> Tuple[bool, Optional[str]]:
+        """Query risk manager and trigger panic sell if entering is disallowed."""
+        if self.risk_manager:
+            allowed, reason = self.risk_manager.can_enter(symbol)
+            if not allowed:
+                asyncio.create_task(self.panic_sell())
+            return allowed, reason
+        return True, None
 
     def status(self) -> Dict[str, Any]:
         return {


### PR DESCRIPTION
## Summary
- Add `panic_sell` to AppState to cancel orders, liquidate non-USDT balances, and stop running loop
- Provide `is_running` and `check_risk` helpers with optional risk manager
- Default `risk_manager` attribute to `None`

## Testing
- `pytest tests/test_panic_sell.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68ba77bdc9b0832d97826bdba7d752a1