### PR TITLE
chore: remove Aura theme css import

### DIFF
--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -1,7 +1,4 @@
-
 @use 'styles/themes/_tokens';
-
-@import '@primeng/themes/aura/theme.css';
 
 /* PrimeIcons */
 @import 'primeicons/primeicons.css';


### PR DESCRIPTION
## Summary
- remove redundant PrimeNG Aura theme CSS import
- confirm Aura preset applied via providePrimeNG

## Testing
- `npm start`


------
https://chatgpt.com/codex/tasks/task_e_68ba82795fa4832da63be1fc6234ca79