### PR TITLE
fix: use styleUrls array in home component

### DIFF
--- a/frontend/src/app/home/home.component.ts
+++ b/frontend/src/app/home/home.component.ts
@@ -12,7 +12,7 @@ import { InputTextModule } from 'primeng/inputtext';
   imports: [CommonModule, ToastModule, ButtonModule, TableModule, InputTextModule],
   providers: [MessageService],
   templateUrl: './home.component.html',
-  styleUrl: './home.component.css'
+  styleUrls: ['./home.component.css']
 })
 export class HomeComponent {
   rows = [


### PR DESCRIPTION
## Summary
- replace deprecated `styleUrl` with `styleUrls` array in HomeComponent

## Testing
- `pytest`
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68ba94051d24832dbb85f5c6f4600a82