### PR TITLE
Simplify routing to remove shell component

### DIFF
--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -1,14 +1,7 @@
 import { Routes } from '@angular/router';
-import { AppShellComponent } from './shell/app-shell.component';
 import { HomeComponent } from './home/home.component';
 
 export const routes: Routes = [
-  {
-    path: '',
-    component: AppShellComponent,
-    children: [
-      { path: '', component: HomeComponent }
-    ]
-  },
+  { path: '', component: HomeComponent },
   { path: '**', redirectTo: '' }
 ];


### PR DESCRIPTION
## Summary
- Remove `AppShellComponent` from route definitions
- Register `HomeComponent` directly under root route

## Testing
- `npm test` *(fails: command not found)*
- `apt-get install -y nodejs npm` *(fails: Unable to locate package nodejs)*

------
https://chatgpt.com/codex/tasks/task_e_68ba96066a40832d89da9a991e258768