### PR TITLE
Restrict CORS settings

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -1,10 +1,22 @@
+import os
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from .routers import trades, risk_ext, backtest
 
 app = FastAPI(title="Amadeus API (patch v12 mega)")
 
-app.add_middleware(CORSMiddleware, allow_origins=["*"], allow_credentials=True, allow_methods=["*"], allow_headers=["*"])
+# Configure CORS settings from environment or defaults
+ALLOWED_ORIGINS = os.getenv("CORS_ALLOW_ORIGINS", "http://localhost:4400").split(",")
+ALLOWED_METHODS = ["GET", "POST"]
+ALLOWED_HEADERS = ["Content-Type"]
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=ALLOWED_ORIGINS,
+    allow_credentials=True,
+    allow_methods=ALLOWED_METHODS,
+    allow_headers=ALLOWED_HEADERS,
+)
 
 app.include_router(trades.router, prefix="/api")
 app.include_router(risk_ext.router, prefix="/api")


### PR DESCRIPTION
## Summary
- Restrict CORS origins, methods, and headers for API with env-driven configuration

## Testing
- `PYTHONPATH=. pytest backend/tests -q`

------
https://chatgpt.com/codex/tasks/task_e_68ba96f6814c832d985a683679e2a0f7