### PR TITLE
fix: import zone.js before other Angular imports

### DIFF
--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,3 +1,4 @@
+import 'zone.js';
 import { bootstrapApplication } from '@angular/platform-browser';
 import { appConfig } from './app/app.config';
 import { AppShellComponent } from './app/layout/app-shell.component';


### PR DESCRIPTION
## Summary
- load zone.js before the Angular bootstrap to avoid NG0908 runtime error

## Testing
- `npm run build` *(fails: Package path ./styles/ag-theme-quartz-dark.css is not exported from package ag-grid-community)*
- `npm start` *(fails: Package path ./styles/ag-theme-quartz-dark.css is not exported from package ag-grid-community)*

------
https://chatgpt.com/codex/tasks/task_e_68ba9c2f6224832dba8de1b872bdef49