### PR TITLE
Register ag-grid community module

### DIFF
--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,8 +1,11 @@
 import 'zone.js';
+import { ModuleRegistry, AllCommunityModule } from 'ag-grid-community';
 import { bootstrapApplication } from '@angular/platform-browser';
 import { appConfig } from './app/app.config';
 import { AppShellComponent } from './app/layout/app-shell.component';
 import { ThemeService } from './app/core/theme/theme.service';
+
+ModuleRegistry.registerModules([AllCommunityModule]);
 
 bootstrapApplication(AppShellComponent, appConfig).then(ref => {
   const theme = ref.injector.get(ThemeService);


### PR DESCRIPTION
## Summary
- register ag-grid's AllCommunityModule before application bootstrap

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: Package path ./styles/ag-theme-quartz-dark.css is not exported from package ag-grid-community)

------
https://chatgpt.com/codex/tasks/task_e_68ba9e85152c832dae17af3ad9ad1779