### PR TITLE
Resolve order book bar color parsing

### DIFF
--- a/frontend/src/app/market/orderbook.component.ts
+++ b/frontend/src/app/market/orderbook.component.ts
@@ -47,13 +47,14 @@ export class OrderbookComponent implements OnInit {
     const size = Number(params.value) || 0;
     const max =  Number(params?.data?.maxSize) || Math.max(size, 1);
     const width = Math.max(0, Math.min(100, Math.round((size / max) * 100)));
-    const isBid = params?.data?.side === 'bid';
-    const color = isBid ? 'var(--buy)' : 'var(--sell)';
+    const colorKey = params?.data?.side === 'bid' ? '--buy' : '--sell';
+    const base = getComputedStyle(document.documentElement)
+      .getPropertyValue(colorKey).trim();
     const el = document.createElement('div');
     el.style.position = 'relative';
     el.style.padding = '0 6px';
     el.textContent = String(size);
-    el.style.background = `linear-gradient(to right, ${color}33 ${width}%, transparent ${width}%)`;
+    el.style.background = `linear-gradient(to right, ${base}33 ${width}%, transparent ${width}%)`;
     return el;
   }
 }


### PR DESCRIPTION
## Summary
- compute CSS background colors for order book bar widths using resolved theme variables

## Testing
- `npm run build` *(fails: Could not resolve "@primeng/themes/aura"; application bundle generation failed)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ba9f4930cc832d9c474b766afcb874