### PR TITLE
feat: show history records with pagination

### DIFF
--- a/frontend/src/app/pages/history.page.ts
+++ b/frontend/src/app/pages/history.page.ts
@@ -1,11 +1,103 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ApiService } from '../core/services/api.service';
+import { OrderHistoryItem, TradeHistoryItem } from '../models';
 
 @Component({
-  selector: 'app-history',
-  standalone: true,
-  template: `
-    <h1>History</h1>
-    <div class="card" style="padding:12px;margin-top:8px;">История сделок (стаб).</div>
-  `
+    selector: 'app-history',
+    standalone: true,
+    imports: [CommonModule],
+    template: `
+        <h1>History</h1>
+
+        <div class="section">
+            <h2>Orders</h2>
+            <table class="tbl">
+                <tr>
+                    <th>Time</th>
+                    <th>Symbol</th>
+                    <th>Side</th>
+                    <th>Price</th>
+                    <th>Qty</th>
+                </tr>
+                <tr *ngFor="let o of orders">
+                    <td>{{ o.ts * 1000 | date:'medium' }}</td>
+                    <td>{{ o.symbol }}</td>
+                    <td>{{ o.side }}</td>
+                    <td>{{ o.price }}</td>
+                    <td>{{ o.qty }}</td>
+                </tr>
+            </table>
+            <div class="pager">
+                <button (click)="prevOrders()" [disabled]="orderOffset === 0">Prev</button>
+                <button (click)="nextOrders()" [disabled]="orders.length < limit">Next</button>
+            </div>
+        </div>
+
+        <div class="section">
+            <h2>Trades</h2>
+            <table class="tbl">
+                <tr>
+                    <th>Time</th>
+                    <th>Symbol</th>
+                    <th>Side</th>
+                    <th>Price</th>
+                    <th>Qty</th>
+                </tr>
+                <tr *ngFor="let t of trades">
+                    <td>{{ t.ts * 1000 | date:'medium' }}</td>
+                    <td>{{ t.symbol }}</td>
+                    <td>{{ t.side }}</td>
+                    <td>{{ t.price }}</td>
+                    <td>{{ t.qty }}</td>
+                </tr>
+            </table>
+            <div class="pager">
+                <button (click)="prevTrades()" [disabled]="tradeOffset === 0">Prev</button>
+                <button (click)="nextTrades()" [disabled]="trades.length < limit">Next</button>
+            </div>
+        </div>
+    `
 })
-export class HistoryPage {}
+export class HistoryPage implements OnInit {
+    limit = 20;
+    orderOffset = 0;
+    tradeOffset = 0;
+    orders: OrderHistoryItem[] = [];
+    trades: TradeHistoryItem[] = [];
+
+    constructor(private api: ApiService) {}
+
+    ngOnInit() {
+        this.loadOrders();
+        this.loadTrades();
+    }
+
+    loadOrders() {
+        this.api.historyOrders(this.limit, this.orderOffset).subscribe(res => this.orders = res?.items || []);
+    }
+
+    loadTrades() {
+        this.api.historyTrades(this.limit, this.tradeOffset).subscribe(res => this.trades = res?.items || []);
+    }
+
+    nextOrders() {
+        this.orderOffset += this.limit;
+        this.loadOrders();
+    }
+
+    prevOrders() {
+        this.orderOffset = Math.max(0, this.orderOffset - this.limit);
+        this.loadOrders();
+    }
+
+    nextTrades() {
+        this.tradeOffset += this.limit;
+        this.loadTrades();
+    }
+
+    prevTrades() {
+        this.tradeOffset = Math.max(0, this.tradeOffset - this.limit);
+        this.loadTrades();
+    }
+}


### PR DESCRIPTION
## Summary
- fetch order and trade history via ApiService
- display history records in tables with pagination controls

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pydantic_settings')*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68baab960d98832d8a7bf0081451df52