### PR TITLE
feat: integrate strategies api

### DIFF
--- a/frontend/src/app/features/strategies/strategies-modern.component.ts
+++ b/frontend/src/app/features/strategies/strategies-modern.component.ts
@@ -1,5 +1,6 @@
-import { Component, signal } from '@angular/core';
+import { Component, EventEmitter, OnInit, Output, inject, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { ApiService } from '../../core/services/api.service';
 
 @Component({
   standalone: true,
@@ -9,20 +10,19 @@ import { CommonModule } from '@angular/common';
   <div class="flex items-center justify-between mb-4">
     <h2 class="text-xl font-semibold">Strategies</h2>
     <div class="flex gap-2">
-      <button class="btn primary" title="Create new strategy (Ctrl+N)">New</button>
-      <button class="btn" title="Import config JSON">Import</button>
+      <button class="btn primary" title="Create new strategy (Ctrl+N)" (click)="create.emit()">New</button>
+      <button class="btn" title="Import config JSON" (click)="importCfg.emit()">Import</button>
     </div>
   </div>
   <div class="grid lg:grid-cols-3 gap-3">
     <div class="card p-4" *ngFor="let s of items()">
       <div class="flex items-center justify-between">
-        <div class="font-medium">{{ s.name }}</div>
+        <div class="font-medium">{{ s.id }}</div>
         <span class="badge" [class.ok]="s.running" [class.err]="!s.running">{{ s.running ? 'running' : 'stopped' }}</span>
       </div>
-      <div class="text-[#9aa4ad] text-xs mt-1">{{ s.symbol }} • {{ s.exchange }}/{{ s.category }}</div>
       <div class="flex items-center gap-3 mt-3">
-        <button class="btn" title="Start">▶</button>
-        <button class="btn" title="Stop">⏸</button>
+        <button class="btn" title="Start" (click)="start(s.id)">▶</button>
+        <button class="btn" title="Stop" (click)="stop(s.id)">⏸</button>
         <button class="btn" title="Edit config">⚙</button>
         <button class="btn" title="Logs">🧾</button>
       </div>
@@ -30,10 +30,30 @@ import { CommonModule } from '@angular/common';
   </div>
   `
 })
-export class StrategiesModernComponent {
-  items = signal([
-    { name: 'sample_ema_crossover', symbol:'BTCUSDT', exchange:'binance', category:'usdt', running: true },
-    { name: 'mean_reversion', symbol:'ETHUSDT', exchange:'bybit', category:'linear', running: false },
-    { name: 'breakout', symbol:'SOLUSDT', exchange:'okx', category:'usdt', running: false },
-  ]);
+export class StrategiesModernComponent implements OnInit {
+  private api = inject(ApiService);
+
+  @Output() create = new EventEmitter<void>();
+  @Output() importCfg = new EventEmitter<void>();
+
+  items = signal<{id: string; running: boolean}[]>([]);
+
+  async ngOnInit() {
+    await this.refresh();
+  }
+
+  private async refresh() {
+    const list = await this.api.listStrategies();
+    this.items.set(list);
+  }
+
+  async start(id: string) {
+    await this.api.startStrategy(id, {});
+    await this.refresh();
+  }
+
+  async stop(id: string) {
+    await this.api.stopStrategy(id);
+    await this.refresh();
+  }
 }

--- a/frontend/src/app/pages/strategies.page.ts
+++ b/frontend/src/app/pages/strategies.page.ts
@@ -1,11 +1,22 @@
 import { Component } from '@angular/core';
+import { StrategiesModernComponent } from '../features/strategies/strategies-modern.component';
 
 @Component({
   selector: 'app-strategies',
   standalone: true,
+  imports: [StrategiesModernComponent],
   template: `
-    <h1>Strategies</h1>
-    <div class="card" style="padding:12px;margin-top:8px;">Управление стратегиями (стаб).</div>
+    <div class="p-4">
+      <app-strategies-modern (create)="onCreate()" (importCfg)="onImport()"></app-strategies-modern>
+    </div>
   `
 })
-export class StrategiesPage {}
+export class StrategiesPage {
+  onCreate() {
+    console.log('Create strategy');
+  }
+
+  onImport() {
+    console.log('Import strategy config');
+  }
+}


### PR DESCRIPTION
## Summary
- load strategies list via ApiService and trigger start/stop actions
- add strategies modern component to page and hook creation/import events

## Testing
- `npm run build` *(fails: Could not resolve "@primeng/themes/aura")*
- `pytest` *(fails: ModuleNotFoundError: No module named 'pydantic_settings')*

------
https://chatgpt.com/codex/tasks/task_e_68baaba87978832d82805313bf0c4d25