### PR TITLE
feat(frontend): provide HttpClient

### DIFF
--- a/frontend/src/app/app.config.ts
+++ b/frontend/src/app/app.config.ts
@@ -1,4 +1,5 @@
 import { ApplicationConfig } from '@angular/core';
+import { provideHttpClient } from '@angular/common/http';
 import { provideRouter } from '@angular/router';
 import { appRoutes } from './app.routes';
 import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
@@ -9,6 +10,7 @@ import Aura from '@primeng/themes/aura';
 export const appConfig: ApplicationConfig = {
   providers: [
     provideRouter(appRoutes),
+    provideHttpClient(),
     provideAnimationsAsync(),
     providePrimeNG({
       theme: {


### PR DESCRIPTION
## Summary
- import and provide HttpClient in Angular app config so ApiService can use HttpClient

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: Could not resolve '@primeng/themes/aura')
- `pytest` (fails: ModuleNotFoundError: No module named 'pydantic_settings')

------
https://chatgpt.com/codex/tasks/task_e_68bb1843bb14832d8ac94ad38c899f74