### PR TITLE
chore: prefix frontend API endpoint

### DIFF
--- a/frontend/src/environments/environment.ts
+++ b/frontend/src/environments/environment.ts
@@ -1,7 +1,7 @@
 export const environment = {
   production: false,
   demo: false,
-  api: 'http://127.0.0.1:8100',
+  api: 'http://127.0.0.1:8100/api',
   ws:  'ws://127.0.0.1:8100/ws',
   token: ''
 };


### PR DESCRIPTION
## Summary
- point frontend environment API to `/api` path so services hit prefixed routes

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68bb2f9b5b3c832db43ca626ed5dab69