### PR TITLE
Disable unsupported frontend API calls

### DIFF
--- a/frontend/src/app/components/controls/controls.component.ts
+++ b/frontend/src/app/components/controls/controls.component.ts
@@ -21,7 +21,7 @@ export class ControlsComponent implements OnDestroy {
   constructor(private api: ApiService, private snack: MatSnackBar) {
     // глобальный стейт запуска бота
     this.sub = this.api.running$.subscribe(v => this.running = !!v);
-    // лёгкий авто-рефреш статуса (как запасной канал, если WS не пришёл)
+    // статус сервера временно недоступен
     this.autoRefreshSub = timer(0, 5000).subscribe(_ => this.refresh());
   }
 
@@ -31,10 +31,7 @@ export class ControlsComponent implements OnDestroy {
   }
 
   refresh() {
-    this.api.status().subscribe({
-      next: s => { this.running = !!s?.running; },
-      error: _ => {}
-    });
+    // статус эндпоинт отключён
   }
 
   async doStart() {
@@ -60,13 +57,7 @@ export class ControlsComponent implements OnDestroy {
       next: _ => {
         this.api.setRunning(false);
         this.running = false;
-        // после остановки показываем финальную статистику
-        this.api.historyStats().subscribe(stats => {
-          this.api.historyTrades(10000, 0).subscribe(res => {
-            const pnl = (res.items || []).reduce((s, t) => s + (t.pnl || 0), 0);
-            this.snack.open(`Стоп. PnL: ${pnl.toFixed(2)}, Trades: ${stats.trades}`, 'OK', { duration: 4000 });
-          });
-        });
+        this.snack.open('Стоп', 'OK', { duration: 4000 });
       },
       error: err => {
         this.snack.open(`Ошибка остановки: ${err?.error?.error || err?.message || 'unknown'}`, 'OK', { duration: 2500 });

--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -2,7 +2,6 @@ import { Component, OnDestroy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { AppMaterialModule } from '../../app.module';
 import { ApiService } from '../../core/services/api.service';
-import { BotStatus } from '../../models';
 import { WsService } from '../../core/services/ws.service';
 import { Subscription } from 'rxjs';
 import { EquitySparklineComponent } from '../equity-sparkline/equity-sparkline.component'; // ⬅️ импорт спарклайна
@@ -31,6 +30,7 @@ export class DashboardComponent implements OnDestroy {
   private sub = new Subscription();
 
   constructor(private api: ApiService, private wsSvc: WsService, private snack: MatSnackBar) {
+    // статус бэкенда недоступен
     this.refreshStatus();
     this.bindWs();
   }
@@ -38,14 +38,7 @@ export class DashboardComponent implements OnDestroy {
   ngOnDestroy(): void { this.sub.unsubscribe(); }
 
   refreshStatus() {
-    this.api.status().subscribe({
-      next: (s: BotStatus) => {
-        this.running = !!s?.running;
-        this.symbol = s?.symbol || '';
-        this.metrics = s?.metrics || {};
-        this.cfg = s?.cfg || {};
-      }
-    });
+    // эндпоинт статуса отключён
   }
 
   private bindWs() {

--- a/frontend/src/app/components/guards/guards.component.ts
+++ b/frontend/src/app/components/guards/guards.component.ts
@@ -1,7 +1,6 @@
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { AppMaterialModule } from '../../app.module';
-import { ApiService } from '../../core/services/api.service';
 
 @Component({
     selector: 'app-guards',
@@ -15,19 +14,16 @@ export class GuardsComponent {
     loading = false;
     error = '';
 
-    constructor(private api: ApiService) {}
+    constructor() {}
 
     ngOnInit() { this.refresh(); }
 
     refresh() {
-        this.loading = true;
-        this.api.getRiskStatus().subscribe({
-            next: (res) => { this.data = res; this.loading = false; this.error=''; },
-            error: (e) => { this.error = e?.message ?? 'Ошибка'; this.loading = false; }
-        });
+        this.loading = false;
+        console.warn('Risk status endpoint not available');
     }
 
     unlock() {
-        this.api.unlockRisk().subscribe({ next: () => this.refresh() });
+        console.warn('Risk unlock endpoint not available');
     }
 }

--- a/frontend/src/app/components/history/history.component.ts
+++ b/frontend/src/app/components/history/history.component.ts
@@ -1,7 +1,6 @@
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { AppMaterialModule } from '../../app.module';
-import { ApiService } from '../../core/services/api.service';
 import { HistoryResponse, HistoryStats, OrderHistoryItem, TradeHistoryItem } from '../../models';
 
 @Component({
@@ -18,40 +17,32 @@ export class HistoryComponent {
     loadingT = false;
     stats: HistoryStats = { orders: 0, trades: 0 };
 
-    constructor(private api: ApiService) {}
+    constructor() {}
 
     ngOnInit() {
         this.refreshAll();
     }
 
     refreshAll() {
-        this.refreshOrders();
-        this.refreshTrades();
-        this.api.historyStats().subscribe(s => this.stats = s);
+        // history endpoints disabled
+        this.orders = [];
+        this.trades = [];
+        this.stats = { orders: 0, trades: 0 };
     }
 
     refreshOrders() {
-        this.loadingO = true;
-        this.api.historyOrders(200, 0).subscribe({
-            next: (res: HistoryResponse<OrderHistoryItem>) => { this.orders = res.items ?? []; this.loadingO = false; },
-            error: () => { this.loadingO = false; }
-        });
+        this.loadingO = false;
     }
 
     refreshTrades() {
-        this.loadingT = true;
-        this.api.historyTrades(200, 0).subscribe({
-            next: (res: HistoryResponse<TradeHistoryItem>) => { this.trades = res.items ?? []; this.loadingT = false; },
-            error: () => { this.loadingT = false; }
-        });
+        this.loadingT = false;
     }
 
     export(kind: 'orders'|'trades') {
-        const url = this.api.historyExportUrl(kind);
-        window.open(url, '_blank');
+        // экспорт истории отключён
     }
 
     clear(kind: 'orders'|'trades'|'all') {
-        this.api.historyClear(kind).subscribe(() => this.refreshAll());
+        // очистка истории отключена
     }
 }

--- a/frontend/src/app/components/risk-widget/risk-widget.component.ts
+++ b/frontend/src/app/components/risk-widget/risk-widget.component.ts
@@ -1,7 +1,6 @@
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { AppMaterialModule } from '../../app.module';
-import { ApiService } from '../../core/services/api.service';
 import { RiskStatus } from '../../models';
 
 @Component({
@@ -16,19 +15,16 @@ export class RiskWidgetComponent {
     data: RiskStatus | null = null;
     err = '';
 
-    constructor(private api: ApiService) {}
+    constructor() {}
 
     ngOnInit() { this.refresh(); }
 
     refresh() {
-        this.loading = true;
-        this.api.getRiskStatus().subscribe({
-            next: (d: RiskStatus) => { this.data = d; this.err = ''; this.loading = false; },
-            error: (e: unknown) => { this.err = String((e as { message?: string })?.message || e); this.loading = false; }
-        });
+        this.loading = false;
+        console.warn('Risk status endpoint not available');
     }
 
     unlock() {
-        this.api.unlockRisk().subscribe(() => this.refresh());
+        console.warn('Risk unlock endpoint not available');
     }
 }

--- a/frontend/src/app/core/services/api.service.ts
+++ b/frontend/src/app/core/services/api.service.ts
@@ -44,7 +44,7 @@ export class ApiService {
   running$ = new BehaviorSubject<boolean>(false);
   setRunning(v: boolean) { this.running$.next(!!v); }
 
-  status() { return this.get('/status'); }
+  // status endpoint not available yet
   start(body?: any) { return this.post('/start', body ?? {}); }
   stop()  { return this.post('/stop', {}); }
   cmd(command: string, payload: any = {}) { return this.post('/cmd', { cmd: command, ...payload }); }
@@ -56,14 +56,7 @@ export class ApiService {
 
   scan(body: any)     { return this.post('/scan', body); }
 
-  historyStats()                      { return this.get('/history/stats'); }
-  historyTrades(limit = 100, offset = 0) { return this.get(`/history/trades?limit=${limit}&offset=${offset}`); }
-  historyOrders(limit = 100, offset = 0) { return this.get(`/history/orders?limit=${limit}&offset=${offset}`); }
-  historyClear(kind: string)          { return this.post('/history/clear', { kind }); }
-  historyExportUrl(kind: string)      { return this.url(`/history/export?kind=${encodeURIComponent(kind)}`); }
-
-  getRiskStatus() { return this.get('/risk/status'); }
-  unlockRisk()    { return this.post('/risk/unlock', {}); }
+  // history and risk endpoints are disabled until backend support
 
   // Methods returning Promises
   getOHLCV(symbol: string, tf = '1m', limit = 200, exchange='mock', category='spot'): Promise<Candle[]> {
@@ -91,20 +84,7 @@ export class ApiService {
     return firstValueFrom(this.http.post(url, {}, { headers: this.headers() }));
   }
 
-  getRiskLimits() {
-    const url = this.url('/risk/limits');
-    return firstValueFrom(this.http.get(url, { headers: this.headers() }));
-  }
-
-  setRiskLimits(body: any) {
-    const url = this.url('/risk/limits');
-    return firstValueFrom(this.http.post(url, body, { headers: this.headers() }));
-  }
-
-  getRiskState() {
-    const url = this.url('/risk/state');
-    return firstValueFrom(this.http.get(url, { headers: this.headers() }));
-  }
+  // risk limits/state endpoints are not available yet
 
   getBalances() {
     const url = this.url('/portfolio/balances');
@@ -141,9 +121,6 @@ export class ApiService {
     return firstValueFrom(this.http.get(url, { headers: this.headers() }));
   }
 
-  getDashboardSummary() {
-    const url = this.url('/dashboard/summary');
-    return firstValueFrom(this.http.get(url, { headers: this.headers() }));
-  }
+  // dashboard summary endpoint not available yet
 }
 

--- a/frontend/src/app/pages/dashboard.component.ts
+++ b/frontend/src/app/pages/dashboard.component.ts
@@ -1,6 +1,6 @@
 import { Component, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { ApiService } from '../core/services/api.service';
+// ApiService removed until backend supports dashboard
 
 @Component({
   standalone: true,
@@ -21,20 +21,7 @@ import { ApiService } from '../core/services/api.service';
     strategies = signal(0);
     orders = signal(0);
 
-    constructor(private api: ApiService) {
-      this.api.status().subscribe();
-      this.loadSummary();
-    }
-
-    private async loadSummary() {
-      try {
-        const summary: any = await this.api.getDashboardSummary();
-        this.equity.set(Number(summary?.equity ?? 0));
-        this.pnl.set(Number(summary?.pnl ?? 0));
-        this.strategies.set(Number(summary?.strategies ?? 0));
-        this.orders.set(Number(summary?.orders ?? 0));
-      } catch (err) {
-        console.error('Failed to load dashboard summary', err);
-      }
+    constructor() {
+      // dashboard summary not available
     }
   }

--- a/frontend/src/app/pages/history.page.ts
+++ b/frontend/src/app/pages/history.page.ts
@@ -1,6 +1,5 @@
 import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { ApiService } from '../core/services/api.service';
 import { OrderHistoryItem, TradeHistoryItem } from '../models';
 
 @Component({
@@ -66,19 +65,18 @@ export class HistoryPage implements OnInit {
     orders: OrderHistoryItem[] = [];
     trades: TradeHistoryItem[] = [];
 
-    constructor(private api: ApiService) {}
+    constructor() {}
 
     ngOnInit() {
-        this.loadOrders();
-        this.loadTrades();
+        // history endpoints disabled
     }
 
     loadOrders() {
-        this.api.historyOrders(this.limit, this.orderOffset).subscribe(res => this.orders = res?.items || []);
+        this.orders = [];
     }
 
     loadTrades() {
-        this.api.historyTrades(this.limit, this.tradeOffset).subscribe(res => this.trades = res?.items || []);
+        this.trades = [];
     }
 
     nextOrders() {

--- a/frontend/src/app/pages/risk.page.ts
+++ b/frontend/src/app/pages/risk.page.ts
@@ -2,7 +2,6 @@ import { Component, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ReactiveFormsModule, FormBuilder, FormGroup } from '@angular/forms';
 import { AppMaterialModule } from '../app.module';
-import { ApiService } from '../core/services/api.service';
 import { RiskStatus } from '../models';
 
 @Component({
@@ -61,7 +60,6 @@ import { RiskStatus } from '../models';
   `
 })
 export class RiskPage {
-  private api = inject(ApiService);
   private fb = inject(FormBuilder);
 
   status: RiskStatus | null = null;
@@ -80,41 +78,24 @@ export class RiskPage {
   loadingLimits = true;
 
   ngOnInit() {
-    this.refreshStatus();
-    this.refreshLimits();
+    // risk endpoints disabled
+    this.loadingStatus = false;
+    this.loadingLimits = false;
   }
 
   refreshStatus() {
-    this.loadingStatus = true;
-    this.api.getRiskStatus().subscribe({
-      next: (d: RiskStatus) => {
-        this.status = d;
-        this.loadingStatus = false;
-      },
-      error: () => {
-        this.loadingStatus = false;
-      },
-    });
+    console.warn('Risk status endpoint not available');
   }
 
   async refreshLimits() {
-    this.loadingLimits = true;
-    try {
-      const lim: any = await this.api.getRiskLimits();
-      if (lim) {
-        this.limitsForm.patchValue(lim);
-      }
-    } finally {
-      this.loadingLimits = false;
-    }
+    console.warn('Risk limits endpoint not available');
   }
 
   async save() {
-    await this.api.setRiskLimits(this.limitsForm.value);
-    this.refreshStatus();
+    console.warn('Risk limits endpoint not available');
   }
 
   unlock() {
-    this.api.unlockRisk().subscribe(() => this.refreshStatus());
+    console.warn('Risk unlock endpoint not available');
   }
 }


### PR DESCRIPTION
## Summary
- remove frontend calls to unsupported status, history, risk and dashboard endpoints
- stub related components to avoid hitting missing backend routes

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb30ce74c4832db2f6b58acbe2be44