### PR TITLE
feat: stream logs over websocket

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,6 +1,7 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, WebSocket, WebSocketDisconnect
 from fastapi.middleware.cors import CORSMiddleware
 from .api.routers import bot, strategies, backtest, ws, config, history, risk
+import asyncio, os
 
 app = FastAPI(title="Amadeus Multi-Exchange MVP", version="0.1.0")
 
@@ -28,3 +29,22 @@ def root():
         "service": "amadeus-mvp",
         "name": "Amadeus Multi-Exchange MVP",
     }
+
+
+LOG_FILE = os.environ.get("LOG_FILE", "bot.log")
+
+
+@app.websocket("/api/ws/logs")
+async def ws_logs(ws: WebSocket):
+    await ws.accept()
+    try:
+        with open(LOG_FILE, "r") as f:
+            f.seek(0, os.SEEK_END)
+            while True:
+                line = f.readline()
+                if line:
+                    await ws.send_text(line.rstrip())
+                else:
+                    await asyncio.sleep(0.2)
+    except WebSocketDisconnect:
+        pass


### PR DESCRIPTION
## Summary
- add `/api/ws/logs` WebSocket endpoint to stream log file lines
- update frontend WebSocket service to point at `/api/ws/logs` and improve error handling

## Testing
- `pytest`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bb461b4a98832d8d44ffc366fdff72