### PR TITLE
Fix WebSocket base path and logs connection

### DIFF
--- a/frontend/src/app/core/services/ws.service.ts
+++ b/frontend/src/app/core/services/ws.service.ts
@@ -27,7 +27,7 @@ export class WsService {
       ? String(wsBase).replace(/\/.*$/, '')
       : String(httpBase).replace(/^http/, 'ws').replace(/\/.*$/, '');
 
-    return host + '/api/ws/logs';
+    return host + '/api/ws';
   }
 
   setBaseUrl(url: string) {

--- a/frontend/src/app/pages/logs.page.ts
+++ b/frontend/src/app/pages/logs.page.ts
@@ -51,7 +51,7 @@ export class LogsPage {
 
   retry() {
     this.status = 'connecting';
-    this.ws.connect('/logs');
+    this.ws.connect('logs');
   }
 
   get filtered(): string[] {


### PR DESCRIPTION
## Summary
- Point WebSocket base URL to `/api/ws`
- Connect logs page via `this.ws.connect('logs')`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Could not resolve "@primeng/themes/aura")*


------
https://chatgpt.com/codex/tasks/task_e_68bb4ddffea4832d93e27d3a2a72aa8b