### PR TITLE
Expose strategies router and update IDs

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -1,7 +1,7 @@
 import os
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from .routers import trades, risk_ext, backtest
+from .routers import trades, risk_ext, backtest, strategies
 
 app = FastAPI(title="Amadeus API (patch v12 mega)")
 
@@ -21,6 +21,7 @@ app.add_middleware(
 app.include_router(trades.router, prefix="/api")
 app.include_router(risk_ext.router, prefix="/api")
 app.include_router(backtest.router, prefix="/api")
+app.include_router(strategies.router, prefix="/api")
 
 @app.get("/healthz")
 def healthz(): return {"ok": True}

--- a/backend/api/routers/strategies.py
+++ b/backend/api/routers/strategies.py
@@ -12,6 +12,8 @@ router = APIRouter(prefix="/strategies", tags=["strategies"])
 
 # NOTE: this is a minimal placeholder; wire it to your real strategy registry
 _registry = {"sample_ema_crossover": {"schema": {"type":"object","properties":{"symbol":{"type":"string","default":"BTCUSDT"},"short":{"type":"integer","default":12},"long":{"type":"integer","default":26},"qty":{"type":"number","default":0.01},"exchange":{"type":"string","default":"binance"},"category":{"type":"string","default":"usdt"}}}}}
+# backwards compatibility alias
+_registry["sample_ema"] = _registry["sample_ema_crossover"]
 _running: Dict[str, Any] = {}
 
 def _gen_cid(prefix: str) -> str:

--- a/frontend/src/app/features/strategies/strategies.component.ts
+++ b/frontend/src/app/features/strategies/strategies.component.ts
@@ -39,7 +39,9 @@ import { JsonSchemaFormComponent } from '../../shared/json-schema-form.component
           <div>
             <label class="block text-sm mb-1">Strategy</label>
             <select class="border rounded p-2 w-full" [(ngModel)]="sid" (ngModelChange)="loadSchema()">
-              <option value="sample_ema_crossover">sample_ema_crossover</option>
+              @for (s of list(); track s.id) {
+                <option [value]="s.id">{{ s.id }}</option>
+              }
             </select>
           </div>
           <div class="col-span-2">
@@ -71,6 +73,10 @@ export class StrategiesComponent {
     const d = await fetch(`${base}/dashboard/summary/strategies`).then(r=>r.json()).catch(()=>({items:[]}));
     const eqMap = new Map(d.items?.map((x:any)=>[x.strategy_id, x.equity]) || []);
     this.list.set(a.map((x:any)=>({ ...x, equity: eqMap.get(x.id) })));
+    if (a.length && !a.find((x:any)=>x.id===this.sid)) {
+      this.sid = a[0].id;
+      await this.loadSchema();
+    }
   }
   async loadSchema() {
     const base = (window as any).__API__ || 'http://localhost:8000/api';

--- a/frontend/src/app/pages/strategies.component.ts
+++ b/frontend/src/app/pages/strategies.component.ts
@@ -6,22 +6,19 @@ import { ApiService } from '../core/services/api.service';
   selector: 'app-strategies',
   template: `
   <h2>Strategies</h2>
-  <button (click)="start()">Start sample_ema</button>
+  <button (click)="start()">Start sample_ema_crossover</button>
   <button (click)="stop()">Stop</button>
   `
 })
 export class StrategiesComponent {
   constructor(private api: ApiService) {}
 
-  start() {
-    const body = {
-      strategy: 'sample_ema',
-      config: { symbol: 'BTCUSDT', tf: '1m', fast: 9, slow: 21, qty: 0.001 }
-    };
-    this.api.start(body).subscribe();
+  async start() {
+    const cfg = { symbol: 'BTCUSDT', tf: '1m', fast: 9, slow: 21, qty: 0.001 };
+    await this.api.startStrategy('sample_ema_crossover', cfg);
   }
 
-  stop() {
-    this.api.stop().subscribe();
+  async stop() {
+    await this.api.stopStrategy('sample_ema_crossover');
   }
 }


### PR DESCRIPTION
## Summary
- expose strategies endpoints under `/api`
- add backwards compatibility alias for `sample_ema`
- frontend uses strategy IDs returned by `/strategies`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb50380a10832d952fae468445543e