### PR TITLE
feat: add strategy detail route

### DIFF
--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -2,6 +2,7 @@ import { Routes } from '@angular/router';
 import { MarketPage } from './market/market.page';
 import { DashboardPageComponent } from './pages/dashboard.component';
 import { StrategiesPage } from './pages/strategies.page';
+import { StrategyDetailComponent } from './features/strategy-detail/strategy-detail.component';
 import { RiskPage } from './pages/risk.page';
 import { HistoryPage } from './pages/history.page';
 import { LogsPage } from './pages/logs.page';
@@ -11,6 +12,7 @@ export const appRoutes: Routes = [
   { path: 'dashboard', component: DashboardPageComponent },
   { path: 'market', component: MarketPage },
   { path: 'strategies', component: StrategiesPage },
+  { path: 'strategies/:sid', component: StrategyDetailComponent },
   { path: 'risk', component: RiskPage },
   { path: 'history', component: HistoryPage },
   { path: 'logs', component: LogsPage },

--- a/frontend/src/app/core/services/api.service.ts
+++ b/frontend/src/app/core/services/api.service.ts
@@ -85,6 +85,16 @@ export class ApiService {
     return firstValueFrom(this.http.post(url, {}, { headers: this.headers() }));
   }
 
+  getStrategyReport(id: string, exchange: string, category: string, symbol: string) {
+    const url = this.url(`/strategy/${id}/report?exchange=${exchange}&category=${category}&symbol=${symbol}`);
+    return firstValueFrom(this.http.get<{report: any}>(url, { headers: this.headers() }));
+  }
+
+  getStrategyFills(id: string, exchange: string, category: string, symbol: string) {
+    const url = this.url(`/strategy/${id}/fills?exchange=${exchange}&category=${category}&symbol=${symbol}`);
+    return firstValueFrom(this.http.get<{items: any[]}>(url, { headers: this.headers() }));
+  }
+
   // ---- risk endpoints ----
 
   getRiskStatus(): Promise<RiskStatus> {

--- a/frontend/src/app/features/strategies/strategies-modern.component.ts
+++ b/frontend/src/app/features/strategies/strategies-modern.component.ts
@@ -1,11 +1,12 @@
 import { Component, EventEmitter, OnInit, Output, inject, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { RouterModule } from '@angular/router';
 import { ApiService } from '../../core/services/api.service';
 
 @Component({
   standalone: true,
   selector: 'app-strategies-modern',
-  imports: [CommonModule],
+  imports: [CommonModule, RouterModule],
   template: `
   <div class="flex items-center justify-between mb-4">
     <h2 class="text-xl font-semibold">Strategies</h2>
@@ -15,18 +16,18 @@ import { ApiService } from '../../core/services/api.service';
     </div>
   </div>
   <div class="grid lg:grid-cols-3 gap-3">
-    <div class="card p-4" *ngFor="let s of items()">
+    <a class="card p-4 block" *ngFor="let s of items()" [routerLink]="['/strategies', s.id]">
       <div class="flex items-center justify-between">
         <div class="font-medium">{{ s.id }}</div>
         <span class="badge" [class.ok]="s.running" [class.err]="!s.running">{{ s.running ? 'running' : 'stopped' }}</span>
       </div>
       <div class="flex items-center gap-3 mt-3">
-        <button class="btn" title="Start" (click)="start(s.id)">▶</button>
-        <button class="btn" title="Stop" (click)="stop(s.id)">⏸</button>
-        <button class="btn" title="Edit config">⚙</button>
-        <button class="btn" title="Logs">🧾</button>
+        <button class="btn" title="Start" (click)="start(s.id); $event.preventDefault(); $event.stopPropagation()">▶</button>
+        <button class="btn" title="Stop" (click)="stop(s.id); $event.preventDefault(); $event.stopPropagation()">⏸</button>
+        <button class="btn" title="Edit config" (click)="$event.preventDefault(); $event.stopPropagation()">⚙</button>
+        <button class="btn" title="Logs" (click)="$event.preventDefault(); $event.stopPropagation()">🧾</button>
       </div>
-    </div>
+    </a>
   </div>
   `
 })

--- a/frontend/src/app/features/strategy-detail/strategy-detail.component.ts
+++ b/frontend/src/app/features/strategy-detail/strategy-detail.component.ts
@@ -1,6 +1,7 @@
 import { Component, inject, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ActivatedRoute } from '@angular/router';
+import { ApiService } from '../../core/services/api.service';
 
 @Component({
   standalone: true,
@@ -49,6 +50,7 @@ import { ActivatedRoute } from '@angular/router';
 })
 export class StrategyDetailComponent {
   route = inject(ActivatedRoute);
+  api = inject(ApiService);
   rep = signal<any>({});
   fills = signal<any[]>([]);
   sid = '';
@@ -56,15 +58,14 @@ export class StrategyDetailComponent {
 
   async ngOnInit() {
     this.sid = this.route.snapshot.params['sid'];
-    const base = (window as any).__API__ || 'http://localhost:8000/api';
-    const url = `${base}/strategy/${this.sid}/report?exchange=${this.exchange}&category=${this.category}&symbol=${this.symbol}`;
-    this.rep.set(await fetch(url).then(r=>r.json()).then(j=>j.report));
-    this.fills.set(await fetch(`${base}/strategy/${this.sid}/fills?exchange=${this.exchange}&category=${this.category}&symbol=${this.symbol}`).then(r=>r.json()).then(j=>j.items));
+    const rep = await this.api.getStrategyReport(this.sid, this.exchange, this.category, this.symbol);
+    this.rep.set(rep.report);
+    const fills = await this.api.getStrategyFills(this.sid, this.exchange, this.category, this.symbol);
+    this.fills.set(fills.items);
   }
 
   csvUrl() {
-    const base = (window as any).__API__ || 'http://localhost:8000/api';
-    return `${base}/strategy/${this.sid}/trades.csv?exchange=${this.exchange}&category=${this.category}&symbol=${this.symbol}`;
+    return this.api.url(`/strategy/${this.sid}/trades.csv?exchange=${this.exchange}&category=${this.category}&symbol=${this.symbol}`);
   }
 
   points() {


### PR DESCRIPTION
## Summary
- add strategy detail route and link strategy cards to details
- use ApiService to load strategy report and fills
- expose API helpers for strategy report and fills

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Could not resolve "@primeng/themes/aura")*


------
https://chatgpt.com/codex/tasks/task_e_68bb55074d44832d93805bd3cd2bbeb8