### PR TITLE
feat: use ApiService helpers for strategy detail

### DIFF
--- a/frontend/src/app/core/services/api.service.ts
+++ b/frontend/src/app/core/services/api.service.ts
@@ -85,14 +85,32 @@ export class ApiService {
     return firstValueFrom(this.http.post(url, {}, { headers: this.headers() }));
   }
 
-  getStrategyReport(id: string, exchange: string, category: string, symbol: string) {
-    const url = this.url(`/strategy/${id}/report?exchange=${exchange}&category=${category}&symbol=${symbol}`);
-    return firstValueFrom(this.http.get<{report: any}>(url, { headers: this.headers() }));
+  async getStrategyReport(
+    id: string,
+    exchange: string,
+    category: string,
+    symbol: string,
+  ): Promise<{ report: any }> {
+    const url = this.url(
+      `/strategy/${id}/report?exchange=${exchange}&category=${category}&symbol=${symbol}`,
+    );
+    return await firstValueFrom(
+      this.http.get<{ report: any }>(url, { headers: this.headers() }),
+    );
   }
 
-  getStrategyFills(id: string, exchange: string, category: string, symbol: string) {
-    const url = this.url(`/strategy/${id}/fills?exchange=${exchange}&category=${category}&symbol=${symbol}`);
-    return firstValueFrom(this.http.get<{items: any[]}>(url, { headers: this.headers() }));
+  async getStrategyFills(
+    id: string,
+    exchange: string,
+    category: string,
+    symbol: string,
+  ): Promise<{ items: any[] }> {
+    const url = this.url(
+      `/strategy/${id}/fills?exchange=${exchange}&category=${category}&symbol=${symbol}`,
+    );
+    return await firstValueFrom(
+      this.http.get<{ items: any[] }>(url, { headers: this.headers() }),
+    );
   }
 
   // ---- risk endpoints ----

--- a/frontend/src/app/features/strategy-detail/strategy-detail.component.ts
+++ b/frontend/src/app/features/strategy-detail/strategy-detail.component.ts
@@ -58,9 +58,11 @@ export class StrategyDetailComponent {
 
   async ngOnInit() {
     this.sid = this.route.snapshot.params['sid'];
-    const rep = await this.api.getStrategyReport(this.sid, this.exchange, this.category, this.symbol);
+    const [rep, fills] = await Promise.all([
+      this.api.getStrategyReport(this.sid, this.exchange, this.category, this.symbol),
+      this.api.getStrategyFills(this.sid, this.exchange, this.category, this.symbol),
+    ]);
     this.rep.set(rep.report);
-    const fills = await this.api.getStrategyFills(this.sid, this.exchange, this.category, this.symbol);
     this.fills.set(fills.items);
   }
 


### PR DESCRIPTION
## Summary
- add async helpers in ApiService for strategy reports and fills
- load strategy report and fills concurrently in StrategyDetailComponent

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Could not resolve "@primeng/themes/aura")*

------
https://chatgpt.com/codex/tasks/task_e_68bb5916d73c832da789f25d83ae2bc1