### PR TITLE
refactor: centralize API access

### DIFF
--- a/frontend/src/app/core/services/auth.service.ts
+++ b/frontend/src/app/core/services/auth.service.ts
@@ -1,16 +1,15 @@
-import { Injectable, signal } from '@angular/core';
+import { Injectable, inject, signal } from '@angular/core';
+import { firstValueFrom } from 'rxjs';
+import { ApiService } from './api.service';
 
 @Injectable({ providedIn: 'root' })
 export class AuthService {
+  api = inject(ApiService);
   role = signal<'admin'|'trader'|'viewer'|'dev'>('dev');
-  base = (window as any).__API__ || 'http://localhost:8000/api';
-  token = (window as any).__TOKEN__ || '';
 
   async whoami() {
-    const headers = this.token ? { 'Authorization': `Bearer ${this.token}` } : {};
     try {
-      const r = await fetch(`${this.base}/auth/whoami`, { headers });
-      const j = await r.json();
+      const j: any = await firstValueFrom(this.api.get('/auth/whoami'));
       if (j?.role) this.role.set(j.role);
     } catch {}
   }

--- a/frontend/src/app/features/analytics/analytics.component.ts
+++ b/frontend/src/app/features/analytics/analytics.component.ts
@@ -2,6 +2,7 @@ import { Component, inject, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { ApiService } from '../../core/services/api.service';
+import { firstValueFrom } from 'rxjs';
 
 @Component({
   standalone: true,
@@ -74,9 +75,13 @@ export class AnalyticsComponent {
   }
 
   async load() {
-    const d = await fetch(`${(this.api as any).base}/analytics/pnl/daily?symbol=${this.symbol}&exchange=${this.exchange}&category=${this.category}`).then(r=>r.json());
+    const d: any = await firstValueFrom(
+      this.api.get(`/analytics/pnl/daily?symbol=${this.symbol}&exchange=${this.exchange}&category=${this.category}`)
+    );
     this.daily.set(d.daily || []);
-    const e = await fetch(`${(this.api as any).base}/analytics/equity/series?symbol=${this.symbol}&exchange=${this.exchange}&category=${this.category}`).then(r=>r.json());
+    const e: any = await firstValueFrom(
+      this.api.get(`/analytics/equity/series?symbol=${this.symbol}&exchange=${this.exchange}&category=${this.category}`)
+    );
     this.equity.set((e.series || []).map((x:any)=>({ ts:x.ts, equity:x.equity })));
   }
 }

--- a/frontend/src/app/features/audit/audit.component.ts
+++ b/frontend/src/app/features/audit/audit.component.ts
@@ -1,6 +1,8 @@
 import { Component, inject, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { AuthService } from '../../core/services/auth.service';
+import { ApiService } from '../../core/services/api.service';
+import { firstValueFrom } from 'rxjs';
 
 @Component({
   standalone: true,
@@ -28,15 +30,13 @@ import { AuthService } from '../../core/services/auth.service';
 })
 export class AuditComponent {
   auth = inject(AuthService);
+  api = inject(ApiService);
   logs = signal<any[]>([]);
-  base = (window as any).__API__ || 'http://localhost:8000/api';
-  token = (window as any).__TOKEN__ || '';
 
   async ngOnInit() {
     await this.auth.whoami();
     if (this.auth.role()!=='admin') return;
-    const headers = this.token ? { 'Authorization': `Bearer ${this.token}` } : {};
-    const r = await fetch(`${this.base}/audit`, { headers });
-    this.logs.set(await r.json());
+    const j = await firstValueFrom(this.api.get('/audit'));
+    this.logs.set(j);
   }
 }

--- a/frontend/src/app/features/trades/trades.component.ts
+++ b/frontend/src/app/features/trades/trades.component.ts
@@ -1,6 +1,8 @@
-import { Component, signal } from '@angular/core';
+import { Component, inject, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
+import { ApiService } from '../../core/services/api.service';
+import { firstValueFrom } from 'rxjs';
 
 @Component({
   standalone: true,
@@ -31,24 +33,24 @@ import { FormsModule } from '@angular/forms';
   `
 })
 export class TradesComponent {
+  api = inject(ApiService);
   symbol=''; exchange=''; category=''; strategy_id='';
   items = signal<any[]>([]);
   async load() {
-    const base = (window as any).__API__ || 'http://localhost:8000/api';
     const params = new URLSearchParams();
     if (this.symbol) params.set('symbol', this.symbol);
     if (this.exchange) params.set('exchange', this.exchange);
     if (this.category) params.set('category', this.category);
     if (this.strategy_id) params.set('strategy_id', this.strategy_id);
-    this.items.set(await fetch(`${base}/trades/fills?${params.toString()}`).then(r=>r.json()).then(j=>j.items));
+    const r: any = await firstValueFrom(this.api.get(`/trades/fills?${params.toString()}`));
+    this.items.set(r.items);
   }
   csvUrl() {
-    const base = (window as any).__API__ || 'http://localhost:8000/api';
     const params = new URLSearchParams();
     if (this.symbol) params.set('symbol', this.symbol);
     if (this.exchange) params.set('exchange', this.exchange);
     if (this.category) params.set('category', this.category);
     if (this.strategy_id) params.set('strategy_id', this.strategy_id);
-    return `${base}/trades/realized.csv?${params.toString()}`;
+    return this.api.url(`/trades/realized.csv?${params.toString()}`);
   }
 }


### PR DESCRIPTION
## Summary
- ensure ApiService strategy helpers target `/strategies/{id}/...`
- replace remaining `fetch` usage in components with ApiService calls
- rebuild frontend assets

## Testing
- `npm run build`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb63ffa3bc832dad104fe5b1ba7e43