### PR TITLE
Expose risk API router

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -5,6 +5,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from .routers import (
     backtest,
+    risk,
     risk_ext,
     strategies,
     strategy_analytics,
@@ -29,6 +30,7 @@ app.add_middleware(
 
 app.include_router(trades.router, prefix="/api")
 app.include_router(risk_ext.router, prefix="/api")
+app.include_router(risk.router, prefix="/api")
 app.include_router(backtest.router, prefix="/api")
 app.include_router(strategies.router, prefix="/api")
 app.include_router(strategy_analytics.router, prefix="/api")


### PR DESCRIPTION
## Summary
- import risk router
- register `/api/risk` endpoints

## Testing
- `pytest`
- `uvicorn backend.api.main:app --port 8000` (curl /api/risk/status)


------
https://chatgpt.com/codex/tasks/task_e_68bb6901c434832db60296826af2bb10