### PR TITLE
Fix WebSocket base URL and error handling

### DIFF
--- a/frontend/src/app/core/services/ws.service.ts
+++ b/frontend/src/app/core/services/ws.service.ts
@@ -23,9 +23,11 @@ export class WsService {
       'http://127.0.0.1:8100/api';
 
     const apiRoot = String(httpBase).replace(/\/$/, '');
-    const derived = apiRoot
-      .replace(/^http/, 'ws')
-      .replace(/\/api$/, '/ws');
+    const derived =
+      apiRoot
+        .replace(/^http/, 'ws')
+        .replace(/\/api(?:\/.*)?$/, '') +
+      '/api/ws';
     const wsBase = this.win.__WS__ || derived;
     return String(wsBase).replace(/\/$/, '');
   }
@@ -76,7 +78,7 @@ export class WsService {
     };
     ws.onerror = (evt) => {
       this.stream$.next(evt as any);
-      this.messages$.next({ type: 'error', message: 'WebSocket connection error', event: evt });
+      this.messages$.next({ type: 'error', message: 'Connection lost. Please retry.', event: evt });
     };
     ws.onmessage = (evt) => {
       this.stream$.next(evt);

--- a/frontend/src/app/pages/logs.page.ts
+++ b/frontend/src/app/pages/logs.page.ts
@@ -44,7 +44,10 @@ export class LogsPage {
     this.ws.stream$.subscribe(evt => {
       if (evt.type === 'open') this.status = 'connected';
       else if (evt.type === 'close') this.status = 'closed';
-      else if (evt.type === 'error') this.status = 'error';
+      else if (evt.type === 'error') {
+        this.status = 'error';
+        this.lines.push('Connection lost. Please retry.');
+      }
     });
     this.retry();
   }


### PR DESCRIPTION
## Summary
- Ensure WebSocket service derives base URL under `/api/ws`
- Show user-friendly message when WebSocket errors occur
- Notify logs page when connection errors happen

## Testing
- `npm test` *(fails: Missing script "test"*)
- `npm run build` *(fails: Could not resolve "@primeuix/themes/aura")*
- `pytest` *(fails: No module named 'pydantic_settings')*

------
https://chatgpt.com/codex/tasks/task_e_68bb692845f0832db7a8c7826fd2d1bb