### PR TITLE
Show warning when strategy data fails to load

### DIFF
--- a/frontend/src/app/features/strategy-detail/strategy-detail.component.ts
+++ b/frontend/src/app/features/strategy-detail/strategy-detail.component.ts
@@ -14,44 +14,43 @@ import { ApiService } from '../../core/services/api.service';
       <a class="px-3 py-2 rounded bg-black text-white" [href]="csvUrl()" target="_blank">Download CSV</a>
     </div>
     @if (error()) {
-      <div class="mt-4">
-        <div class="text-red-500 mb-2">{{ error() }}</div>
+      <div class="mt-4 flex items-center gap-2">
+        <div class="text-yellow-600">{{ error() }}</div>
         <button class="px-3 py-2 rounded bg-black text-white" (click)="load()">Retry</button>
       </div>
-    } @else {
-      <div class="grid md:grid-cols-2 gap-6 mt-4">
-        <div>
-          <h3 class="font-medium mb-2">Metrics</h3>
-          <div class="grid grid-cols-2 gap-3 text-sm">
-            <div class="border rounded p-3"><div class="text-gray-500">Sharpe</div><div class="text-lg font-bold">{{ rep()?.sharpe | number:'1.2-2' }}</div></div>
-            <div class="border rounded p-3"><div class="text-gray-500">Sortino</div><div class="text-lg font-bold">{{ rep()?.sortino | number:'1.2-2' }}</div></div>
-            <div class="border rounded p-3"><div class="text-gray-500">Calmar</div><div class="text-lg font-bold">{{ rep()?.calmar | number:'1.2-2' }}</div></div>
-            <div class="border rounded p-3"><div class="text-gray-500">Max DD</div><div class="text-lg font-bold">{{ rep()?.maxdd | percent:'1.2-2' }}</div></div>
-            <div class="border rounded p-3"><div class="text-gray-500">Win Rate</div><div class="text-lg font-bold">{{ rep()?.winrate | percent:'1.0-0' }}</div></div>
-            <div class="border rounded p-3"><div class="text-gray-500">Profit Factor</div><div class="text-lg font-bold">{{ rep()?.profit_factor | number:'1.2-2' }}</div></div>
-            <div class="border rounded p-3"><div class="text-gray-500">CAGR</div><div class="text-lg font-bold">{{ rep()?.cagr | percent:'1.2-2' }}</div></div>
-            <div class="border rounded p-3 col-span-2"><div class="text-gray-500">Realized PnL (net)</div><div class="text-lg font-bold">{{ rep()?.pnl_total | number:'1.2-2' }}</div></div>
-          </div>
-          <div class="mt-4 border rounded p-3">
-            <div class="font-medium mb-2">Last Fills</div>
-            <table class="w-full text-sm">
-              <thead><tr class="text-left"><th>Time</th><th>Side</th><th>Qty</th><th>Price</th></tr></thead>
-              <tbody>
-                @for (f of fills(); track f.ts) {
-                  <tr><td>{{ f.ts }}</td><td>{{ f.side }}</td><td>{{ f.qty }}</td><td>{{ f.price }}</td></tr>
-                }
-              </tbody>
-            </table>
-          </div>
+    }
+    <div class="grid md:grid-cols-2 gap-6 mt-4">
+      <div>
+        <h3 class="font-medium mb-2">Metrics</h3>
+        <div class="grid grid-cols-2 gap-3 text-sm">
+          <div class="border rounded p-3"><div class="text-gray-500">Sharpe</div><div class="text-lg font-bold">{{ rep()?.sharpe | number:'1.2-2' }}</div></div>
+          <div class="border rounded p-3"><div class="text-gray-500">Sortino</div><div class="text-lg font-bold">{{ rep()?.sortino | number:'1.2-2' }}</div></div>
+          <div class="border rounded p-3"><div class="text-gray-500">Calmar</div><div class="text-lg font-bold">{{ rep()?.calmar | number:'1.2-2' }}</div></div>
+          <div class="border rounded p-3"><div class="text-gray-500">Max DD</div><div class="text-lg font-bold">{{ rep()?.maxdd | percent:'1.2-2' }}</div></div>
+          <div class="border rounded p-3"><div class="text-gray-500">Win Rate</div><div class="text-lg font-bold">{{ rep()?.winrate | percent:'1.0-0' }}</div></div>
+          <div class="border rounded p-3"><div class="text-gray-500">Profit Factor</div><div class="text-lg font-bold">{{ rep()?.profit_factor | number:'1.2-2' }}</div></div>
+          <div class="border rounded p-3"><div class="text-gray-500">CAGR</div><div class="text-lg font-bold">{{ rep()?.cagr | percent:'1.2-2' }}</div></div>
+          <div class="border rounded p-3 col-span-2"><div class="text-gray-500">Realized PnL (net)</div><div class="text-lg font-bold">{{ rep()?.pnl_total | number:'1.2-2' }}</div></div>
         </div>
-        <div>
-          <h3 class="font-medium mb-2">Equity</h3>
-          <svg [attr.viewBox]="'0 0 400 200'" class="w-full border rounded">
-            <polyline [attr.points]="points()" fill="none" stroke="currentColor"></polyline>
-          </svg>
+        <div class="mt-4 border rounded p-3">
+          <div class="font-medium mb-2">Last Fills</div>
+          <table class="w-full text-sm">
+            <thead><tr class="text-left"><th>Time</th><th>Side</th><th>Qty</th><th>Price</th></tr></thead>
+            <tbody>
+              @for (f of fills(); track f.ts) {
+                <tr><td>{{ f.ts }}</td><td>{{ f.side }}</td><td>{{ f.qty }}</td><td>{{ f.price }}</td></tr>
+              }
+            </tbody>
+          </table>
         </div>
       </div>
-    }
+      <div>
+        <h3 class="font-medium mb-2">Equity</h3>
+        <svg [attr.viewBox]="'0 0 400 200'" class="w-full border rounded">
+          <polyline [attr.points]="points()" fill="none" stroke="currentColor"></polyline>
+        </svg>
+      </div>
+    </div>
   </div>
   `
 })


### PR DESCRIPTION
## Summary
- Show warning and retry button when strategy report or fills fail to load
- Keep page content visible even when strategy API calls fail

## Testing
- `npm run build`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb6b05e3c0832d9f5154c40ba6045e