### PR TITLE
feat: expose log streaming websocket

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -20,7 +20,7 @@ app.include_router(strategies.router, prefix="/api")
 app.include_router(backtest.router, prefix="/api")
 app.include_router(history.router, prefix="/api")
 app.include_router(risk.router, prefix="/api")
-app.include_router(ws.router)  # /ws
+app.include_router(ws.router, prefix="/api")  # /api/ws
 
 @app.get("/")
 def root():

--- a/frontend/src/app/components/logs/logs.component.ts
+++ b/frontend/src/app/components/logs/logs.component.ts
@@ -25,7 +25,8 @@ export class LogsComponent {
     constructor(private ws: WsService, private zone: NgZone) {}
 
     ngOnInit() {
-        this.ws.connect();
+        const ws = this.ws.connect('logs');
+        if (!ws) this.zone.run(() => this.onEvent({ type: 'error' }));
         this.ws.stream$.subscribe((evt: any) => {
             this.zone.run(() => this.onEvent(evt));
         });
@@ -42,6 +43,18 @@ export class LogsComponent {
         else if (evt.type) { type = String(evt.type); }
 
         switch (type) {
+            case 'error':
+                type = 'diag';
+                text = 'Connection lost. Please retry.';
+                break;
+            case 'open':
+                type = 'diag';
+                text = 'Connected';
+                break;
+            case 'close':
+                type = 'diag';
+                text = 'WebSocket closed';
+                break;
             case 'status':
                 text = `running=${evt.running} equity=${evt.equity ?? ''} symbol=${evt.symbol ?? ''}`;
                 break;

--- a/frontend/src/app/core/services/ws.service.ts
+++ b/frontend/src/app/core/services/ws.service.ts
@@ -25,7 +25,6 @@ export class WsService {
     const apiRoot = String(httpBase).replace(/\/$/, '');
     const derived =
       apiRoot
-        .replace(/^http/, 'ws')
         .replace(/\/api(?:\/.*)?$/, '') +
       '/api/ws';
     const wsBase = this.win.__WS__ || derived;
@@ -52,7 +51,8 @@ export class WsService {
     }
 
     const adj = channel ? '/' + String(channel).replace(/^\//, '') : '';
-    const url = this.baseUrl + adj;
+    const base = this.baseUrl.replace(/^http/, 'ws');
+    const url = base + adj;
 
     if (this.socket) {
       try { this.socket.close(); } catch {}

--- a/frontend/src/app/pages/logs.page.ts
+++ b/frontend/src/app/pages/logs.page.ts
@@ -54,7 +54,11 @@ export class LogsPage {
 
   retry() {
     this.status = 'connecting';
-    this.ws.connect('logs');
+    const ws = this.ws.connect('logs');
+    if (!ws) {
+      this.status = 'error';
+      this.lines.push('Failed to connect to log stream.');
+    }
   }
 
   get filtered(): string[] {

--- a/tests/test_ws_close.py
+++ b/tests/test_ws_close.py
@@ -4,7 +4,7 @@ from fastapi.testclient import TestClient
 
 def test_websocket_close_is_idempotent(client: TestClient, caplog):
     with caplog.at_level(logging.ERROR):
-        with client.websocket_connect("/ws?token=test-token") as ws:
+        with client.websocket_connect("/api/ws?token=test-token") as ws:
             ws.close()
             ws.close()
     assert "Failed to close websocket" not in caplog.text


### PR DESCRIPTION
## Summary
- expose generic websocket endpoint under `/api/ws`
- stream log file contents over `/api/ws/logs`
- connect frontend logs components to new endpoint and surface errors
- normalize WebSocket base URL resolution
- adjust test to new websocket path

## Testing
- `pytest`
- `cd frontend && npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68bb6f021658832dae47d136dd14b55f