### PR TITLE
Implement history page fetching with pagination

### DIFF
--- a/frontend/src/app/core/services/api.service.ts
+++ b/frontend/src/app/core/services/api.service.ts
@@ -2,7 +2,7 @@ import { Injectable, inject } from '@angular/core';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { BehaviorSubject, Observable, firstValueFrom } from 'rxjs';
 import { environment } from '../../../environments/environment';
-import { RiskStatus } from '../../models';
+import { RiskStatus, HistoryResponse, OrderHistoryItem, TradeHistoryItem } from '../../models';
 
 export interface Candle { ts:number; o:number; h:number; l:number; c:number; v:number; tf:string; symbol:string; }
 
@@ -56,8 +56,19 @@ export class ApiService {
   restoreConfig()     { return this.post('/config/restore', {}); }
 
   scan(body: any)     { return this.post('/scan', body); }
+  historyOrders(limit = 20, offset = 0) {
+    const url = this.url(`/history/orders?limit=${limit}&offset=${offset}`);
+    return firstValueFrom(
+      this.http.get<HistoryResponse<OrderHistoryItem>>(url, { headers: this.headers() }),
+    );
+  }
 
-  // history and risk endpoints are disabled until backend support
+  historyTrades(limit = 20, offset = 0) {
+    const url = this.url(`/history/trades?limit=${limit}&offset=${offset}`);
+    return firstValueFrom(
+      this.http.get<HistoryResponse<TradeHistoryItem>>(url, { headers: this.headers() }),
+    );
+  }
 
   // Methods returning Promises
   getOHLCV(symbol: string, tf = '1m', limit = 200, exchange='mock', category='spot'): Promise<Candle[]> {

--- a/frontend/src/app/pages/history.page.ts
+++ b/frontend/src/app/pages/history.page.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { OrderHistoryItem, TradeHistoryItem } from '../models';
+import { ApiService } from '../core/services/api.service';
 
 @Component({
     selector: 'app-history',
@@ -8,8 +9,6 @@ import { OrderHistoryItem, TradeHistoryItem } from '../models';
     imports: [CommonModule],
     template: `
         <h1>History</h1>
-        <p class="construction">Feature under construction</p>
-
         <div class="section">
             <h2>Orders</h2>
             <table class="tbl">
@@ -66,18 +65,23 @@ export class HistoryPage implements OnInit {
     orders: OrderHistoryItem[] = [];
     trades: TradeHistoryItem[] = [];
 
-    constructor() {}
+    constructor(private api: ApiService) {}
 
     ngOnInit() {
-        // history endpoints disabled
+        this.loadOrders();
+        this.loadTrades();
     }
 
     loadOrders() {
-        this.orders = [];
+        this.api
+            .historyOrders(this.limit, this.orderOffset)
+            .then((res) => (this.orders = res.items ?? []));
     }
 
     loadTrades() {
-        this.trades = [];
+        this.api
+            .historyTrades(this.limit, this.tradeOffset)
+            .then((res) => (this.trades = res.items ?? []));
     }
 
     nextOrders() {


### PR DESCRIPTION
## Summary
- Integrate ApiService into history page to load orders and trades with limit/offset pagination
- Add historyOrders/historyTrades methods in ApiService for paginated history endpoints

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Could not resolve "@primeuix/themes/aura")*
- `pytest` *(fails: ModuleNotFoundError: No module named 'pydantic_settings')*


------
https://chatgpt.com/codex/tasks/task_e_68bb73d00968832db9f9ef36aed895ed