### PR TITLE
fix(api): restore dashboard and history endpoints

### DIFF
--- a/frontend/src/app/core/services/api.service.ts
+++ b/frontend/src/app/core/services/api.service.ts
@@ -56,13 +56,17 @@ export class ApiService {
   restoreConfig()     { return this.post('/config/restore', {}); }
 
   scan(body: any)     { return this.post('/scan', body); }
+  // history and risk endpoints are disabled until backend support
   historyOrders(limit = 20, offset = 0) {
     const url = this.url(`/history/orders?limit=${limit}&offset=${offset}`);
     return firstValueFrom(
       this.http.get<HistoryResponse<OrderHistoryItem>>(url, { headers: this.headers() }),
     );
   }
-
+  getDashboardSummary() {
+    const url = this.url('/dashboard/summary');
+    return firstValueFrom(this.http.get(url, { headers: this.headers() }));
+  }
   historyTrades(limit = 20, offset = 0) {
     const url = this.url(`/history/trades?limit=${limit}&offset=${offset}`);
     return firstValueFrom(


### PR DESCRIPTION
## Summary
- add missing getDashboardSummary helper and keep historyTrades
- document unsupported history/risk endpoints

## Testing
- `npm run build`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb7834ef20832d8fe1b46537529a50