### PR TITLE
Add summary and status endpoints

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -1,6 +1,7 @@
 import os
+import time
 
-from fastapi import FastAPI
+from fastapi import FastAPI, APIRouter
 from fastapi.middleware.cors import CORSMiddleware
 
 from .routers import (
@@ -14,6 +15,17 @@ from .routers import (
 )
 
 app = FastAPI(title="Amadeus API (patch v12 mega)")
+START_TIME = time.time()
+
+status_router = APIRouter()
+
+
+@status_router.get("/status")
+def api_status():
+    """Return basic health information with uptime and version."""
+    uptime = time.time() - START_TIME
+    version = os.getenv("APP_VERSION", "dev")
+    return {"ok": True, "uptime": uptime, "version": version}
 
 # Configure CORS settings from environment or defaults
 ALLOWED_ORIGINS = os.getenv("CORS_ALLOW_ORIGINS", "http://localhost:4400").split(",")
@@ -28,6 +40,7 @@ app.add_middleware(
     allow_headers=ALLOWED_HEADERS,
 )
 
+app.include_router(status_router, prefix="/api")
 app.include_router(trades.router, prefix="/api")
 app.include_router(risk_ext.router, prefix="/api")
 app.include_router(risk.router, prefix="/api")

--- a/backend/api/routers/dashboard.py
+++ b/backend/api/routers/dashboard.py
@@ -1,9 +1,30 @@
 from fastapi import APIRouter, Depends
 from sqlmodel import Session, select
+
 from backend.core.db import get_session
-from backend.core.models import EquitySnapshotRow
+from backend.core.models import EquitySnapshotRow, RealizedPnlRow
+from .strategies import _running
 
 router = APIRouter(prefix="/dashboard", tags=["dashboard"])
+
+@router.get("/summary")
+def total_summary(session: Session = Depends(get_session)):
+    # aggregate total equity across latest snapshots and realized pnl
+    stmt = select(EquitySnapshotRow).order_by(
+        EquitySnapshotRow.symbol,
+        EquitySnapshotRow.strategy_id,
+        EquitySnapshotRow.ts.desc(),
+    )
+    rows = list(session.exec(stmt))
+    latest = {}
+    for r in rows:
+        key = (r.strategy_id or "n/a", r.symbol, r.exchange, r.category)
+        if key not in latest:
+            latest[key] = r
+    total_equity = sum(r.equity for r in latest.values())
+    total_pnl = sum(r.pnl for r in session.exec(select(RealizedPnlRow)))
+    running = len(_running)
+    return {"equity": total_equity, "pnl": total_pnl, "running_strategies": running}
 
 @router.get("/summary/strategies")
 def per_strategy_summary(session: Session = Depends(get_session)):


### PR DESCRIPTION
## Summary
- provide dashboard summary totals for equity, pnl, and running strategies
- expose API status endpoint with uptime and version details

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bb7f40e41c832dbcb5ac9f5d3feb03