### PR TITLE
feat(frontend): add risk page success messaging

### DIFF
--- a/frontend/src/app/pages/risk.page.ts
+++ b/frontend/src/app/pages/risk.page.ts
@@ -97,14 +97,15 @@ export class RiskPage {
   }
 
   ngOnInit() {
-    this.refreshStatus();
-    this.refreshLimits();
+    this.refreshStatus(true);
+    this.refreshLimits(true);
   }
 
-  async refreshStatus() {
+  async refreshStatus(silent = false) {
     this.loadingStatus = true;
     try {
       this.status = await this.api.getRiskStatus();
+      if (!silent) alert('Risk status loaded');
     } catch (err) {
       this.handleError('Failed to load risk status', err);
     } finally {
@@ -112,11 +113,12 @@ export class RiskPage {
     }
   }
 
-  async refreshLimits() {
+  async refreshLimits(silent = false) {
     this.loadingLimits = true;
     try {
       const limits = await this.api.getRiskLimits();
       this.limitsForm.patchValue(limits || {});
+      if (!silent) alert('Risk limits loaded');
     } catch (err) {
       this.handleError('Failed to load risk limits', err);
     } finally {
@@ -128,7 +130,8 @@ export class RiskPage {
     this.loadingLimits = true;
     try {
       await this.api.setRiskLimits(this.limitsForm.value);
-      await this.refreshLimits();
+      alert('Risk limits saved');
+      await this.refreshLimits(true);
     } catch (err) {
       this.handleError('Failed to save risk limits', err);
     } finally {
@@ -139,7 +142,8 @@ export class RiskPage {
   async unlock() {
     try {
       await this.api.unlockRisk();
-      await this.refreshStatus();
+      alert('Risk unlocked');
+      await this.refreshStatus(true);
     } catch (err) {
       this.handleError('Failed to unlock risk', err);
     }


### PR DESCRIPTION
## Summary
- show alerts when risk status or limits are loaded and after saving or unlocking risk
- support silent refresh to suppress initial alerts

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb800f2d18832d9ef826090b1d5566