### PR TITLE
Add websocket log streaming route

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -5,6 +5,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from .routers import (
     backtest,
+    observability,
     risk,
     risk_ext,
     strategies,
@@ -28,6 +29,7 @@ app.add_middleware(
     allow_headers=ALLOWED_HEADERS,
 )
 
+app.include_router(observability.router, prefix="/api")
 app.include_router(trades.router, prefix="/api")
 app.include_router(risk_ext.router, prefix="/api")
 app.include_router(risk.router, prefix="/api")

--- a/backend/api/routers/observability.py
+++ b/backend/api/routers/observability.py
@@ -1,0 +1,24 @@
+import os
+import asyncio
+
+from fastapi import APIRouter, WebSocket, WebSocketDisconnect
+
+router = APIRouter(tags=["observability"])
+
+LOG_FILE = os.environ.get("LOG_FILE", "bot.log")
+
+
+@router.websocket("/ws/logs")
+async def ws_logs(ws: WebSocket):
+    await ws.accept()
+    try:
+        with open(LOG_FILE, "r") as f:
+            f.seek(0, os.SEEK_END)
+            while True:
+                line = f.readline()
+                if line:
+                    await ws.send_text(line.rstrip())
+                else:
+                    await asyncio.sleep(0.2)
+    except WebSocketDisconnect:
+        pass


### PR DESCRIPTION
## Summary
- Add observability router with `/ws/logs` websocket that streams log lines from a file
- Mount observability router under the `/api` prefix in main FastAPI app

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bb7ff0e9c4832da22f4e66e972d79e