### PR TITLE
Add status endpoint and observability router

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -1,9 +1,10 @@
 import os
 import time
 
-from fastapi import FastAPI, APIRouter
+from fastapi import APIRouter, FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
+from backend.observability import router as observability_router
 from .routers import (
     backtest,
     risk,
@@ -41,6 +42,7 @@ app.add_middleware(
 )
 
 app.include_router(status_router, prefix="/api")
+app.include_router(observability_router, prefix="/api")
 app.include_router(trades.router, prefix="/api")
 app.include_router(risk_ext.router, prefix="/api")
 app.include_router(risk.router, prefix="/api")

--- a/backend/observability/__init__.py
+++ b/backend/observability/__init__.py
@@ -1,0 +1,11 @@
+from fastapi import APIRouter
+
+from .otel import setup_otel
+
+router = APIRouter(prefix="/observability", tags=["observability"])
+
+
+@router.get("/ping")
+def ping() -> dict:
+    """Simple endpoint for observability checks."""
+    return {"ok": True}


### PR DESCRIPTION
## Summary
- reintroduce status router with uptime and version reporting
- expose observability router under /api for future monitoring

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bb8351ddb0832d948c445395ee9fc1