### PR TITLE
Handle missing log files in WebSocket log streams

### DIFF
--- a/backend/api/routers/observability.py
+++ b/backend/api/routers/observability.py
@@ -36,10 +36,6 @@ async def ws_logs(ws: WebSocket):
     """Stream log lines to the client using a non-blocking file tail."""
     await ws.accept()
     try:
-        if not os.path.exists(LOG_PATH):
-            await ws.close(code=1003)
-            return
-
         f = await asyncio.to_thread(open, LOG_PATH, "r")
         try:
             await asyncio.to_thread(f.seek, 0, os.SEEK_END)
@@ -51,5 +47,8 @@ async def ws_logs(ws: WebSocket):
                     await asyncio.sleep(0.2)
         finally:
             await asyncio.to_thread(f.close)
+    except FileNotFoundError:
+        await ws.send_text("Log file not found")
+        await ws.close(code=1003)
     except WebSocketDisconnect:
         pass

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -46,5 +46,8 @@ async def ws_logs(ws: WebSocket):
                     await ws.send_text(line.rstrip())
                 else:
                     await asyncio.sleep(0.2)
+    except FileNotFoundError:
+        await ws.send_text("Log file not found")
+        await ws.close(code=1003)
     except WebSocketDisconnect:
         pass


### PR DESCRIPTION
## Summary
- close WebSocket log streams gracefully when log file is missing
- notify clients when the log file doesn't exist for both API and app endpoints

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bb859ed3cc832d8ebf9f17daa46a98