### PR TITLE
feat(ui): improve strategy forms

### DIFF
--- a/frontend/src/app/features/strategy-detail/strategy-detail.component.ts
+++ b/frontend/src/app/features/strategy-detail/strategy-detail.component.ts
@@ -69,18 +69,26 @@ export class StrategyDetailComponent {
   }
 
   async load() {
+    let errMsg: string | null = null;
     try {
-      const [rep, fills] = await Promise.all([
-        this.api.getStrategyReport(this.sid, this.exchange, this.category, this.symbol),
-        this.api.getStrategyFills(this.sid, this.exchange, this.category, this.symbol),
-      ]);
+      const rep = await this.api.getStrategyReport(this.sid, this.exchange, this.category, this.symbol);
       this.rep.set(rep.report);
-      this.fills.set(fills.items);
-      this.error.set(null);
     } catch (e) {
       console.error('Failed to load strategy report', e);
-      this.error.set('Report not available');
+      this.rep.set({});
+      errMsg = 'Report not available';
     }
+
+    try {
+      const fills = await this.api.getStrategyFills(this.sid, this.exchange, this.category, this.symbol);
+      this.fills.set(fills.items);
+    } catch (e) {
+      console.error('Failed to load strategy fills', e);
+      this.fills.set([]);
+      errMsg = errMsg ? errMsg + '; fills not available' : 'Fills not available';
+    }
+
+    this.error.set(errMsg);
   }
 
   csvUrl() {


### PR DESCRIPTION
## Summary
- load strategy schemas and defaults before starting
- surface equity and running status in strategy list via summary
- isolate report/fills requests with fallback messaging

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Could not resolve "@primeuix/themes/aura")*


------
https://chatgpt.com/codex/tasks/task_e_68bb865a1c04832d9f5281d2afdef050