### PR TITLE
refactor websocket url handling

### DIFF
--- a/frontend/src/app/core/services/ws.service.ts
+++ b/frontend/src/app/core/services/ws.service.ts
@@ -14,16 +14,19 @@ export class WsService {
   private get baseUrl(): string {
     if (this.baseOverride) return this.baseOverride;
 
-    const apiBase = String((environment as any).api || 'http://127.0.0.1:8100/api')
+    return String((environment as any).api || 'http://127.0.0.1:8100/api')
       .replace(/\/$/, '')
       .replace(/^http/, 'ws')
-      .replace(/\/api(?:\/.*)?$/, '/api/ws');
-
-    return apiBase.replace(/\/$/, '');
+      .replace(/\/api(?:\/.*)?$/, '/api/ws/');
   }
 
   setBaseUrl(url: string) {
-    this.baseOverride = url ? String(url).replace(/\/$/, '') : undefined;
+    this.baseOverride = url
+      ? String(url)
+          .replace(/\/$/, '')
+          .replace(/^http/, 'ws')
+          .replace(/\/api(?:\/.*)?$/, '/api/ws/')
+      : undefined;
   }
 
   connect(channel: string = ''): WebSocket | undefined {
@@ -52,8 +55,7 @@ export class WsService {
     if (this.messages$.isStopped) this.messages$ = new Subject<any>();
     if (this.stream$.isStopped) this.stream$ = new Subject<Event>();
 
-    const adj = channel ? '/' + String(channel).replace(/^\//, '') : '';
-    const url = this.baseUrl + adj;
+    const url = this.baseUrl + channel;
 
     if (this.socket) {
       try {

--- a/frontend/src/app/features/portfolio/portfolio.component.ts
+++ b/frontend/src/app/features/portfolio/portfolio.component.ts
@@ -56,8 +56,7 @@ export class PortfolioComponent {
   async ngOnInit() {
     this.balances.set(await this.api.getBalances());
     this.positions.set(await this.api.getPositions());
-    const base = (window as any).__WS__ || 'ws://localhost:8000/api/portfolio/ws';
-    this.ws.connect(`${base}/fills`);
+    this.ws.connect('portfolio/fills');
     this.ws.messages$.subscribe((m) => {
       if (m?.type === 'fill') {
         this.liveFills.update(arr => (arr.length>200? arr.slice(-200):arr).concat(m));


### PR DESCRIPTION
## Summary
- ensure WsService baseUrl terminates at `/api/ws/`
- simplify connect logic and normalize override URLs
- update portfolio WebSocket usage

## Testing
- `npm test` (fails: Missing script "test")
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb8afd97a0832d8d9acb80c354309d