### PR TITLE
Show strategy metrics and last fills

### DIFF
--- a/frontend/src/app/core/services/api.service.ts
+++ b/frontend/src/app/core/services/api.service.ts
@@ -128,6 +128,23 @@ export class ApiService {
     );
   }
 
+  async getStrategySummary(
+    id: string,
+    exchange: string,
+    category: string,
+    symbol: string,
+    limit = 5,
+  ): Promise<{ report: any; fills: any[] }> {
+    const url = this.url(
+      `/strategies/${id}/summary?exchange=${exchange}&category=${category}&symbol=${symbol}&limit=${limit}`,
+    );
+    return await firstValueFrom(
+      this.http.get<{ report: any; fills: any[] }>(url, {
+        headers: this.headers(),
+      }),
+    );
+  }
+
   // ---- risk endpoints ----
 
   getRiskStatus(): Promise<RiskStatus> {

--- a/frontend/src/app/features/strategies/strategies-modern.component.ts
+++ b/frontend/src/app/features/strategies/strategies-modern.component.ts
@@ -23,6 +23,20 @@ import { ApiService } from '../../core/services/api.service';
         <div class="font-medium">{{ s.id }}</div>
         <span class="badge" [class.ok]="s.running" [class.err]="!s.running">{{ s.running ? 'running' : 'stopped' }}</span>
       </div>
+      <div class="grid grid-cols-2 gap-1 text-xs mt-3" *ngIf="s.report">
+        <div>Sharpe: {{ s.report.sharpe | number:'1.2-2' }}</div>
+        <div>Sortino: {{ s.report.sortino | number:'1.2-2' }}</div>
+        <div>Calmar: {{ s.report.calmar | number:'1.2-2' }}</div>
+        <div>Max DD: {{ s.report.maxdd | percent:'1.0-2' }}</div>
+        <div>Win Rate: {{ s.report.winrate | percent:'1.0-0' }}</div>
+        <div>Profit Factor: {{ s.report.profit_factor | number:'1.2-2' }}</div>
+        <div>CAGR: {{ s.report.cagr | percent:'1.2-2' }}</div>
+        <div>PnL: {{ s.report.pnl_total | number:'1.2-2' }}</div>
+      </div>
+      <div class="mt-2 text-xs" *ngIf="s.fills?.length">
+        <div class="font-medium">Last Fills</div>
+        <div *ngFor="let f of s.fills">{{ f.side }} {{ f.qty }} @ {{ f.price }}</div>
+      </div>
       <div class="flex items-center gap-3 mt-3">
         <button class="btn" title="Edit" (click)="edit.emit(s.id); $event.preventDefault(); $event.stopPropagation()">⚙</button>
         <button class="btn" title="Delete" (click)="remove.emit(s.id); $event.preventDefault(); $event.stopPropagation()">🗑</button>
@@ -41,7 +55,10 @@ export class StrategiesModernComponent implements OnInit {
   @Output() edit = new EventEmitter<string>();
   @Output() remove = new EventEmitter<string>();
 
-  items = signal<{id: string; running: boolean}[]>([]);
+  items = signal<{id: string; running: boolean; report?: any; fills?: any[]}[]>([]);
+  exchange = 'binance';
+  category = 'usdt';
+  symbol = 'BTCUSDT';
 
   async ngOnInit() {
     await this.refresh();
@@ -50,6 +67,23 @@ export class StrategiesModernComponent implements OnInit {
   async refresh() {
     try {
       const list = await this.api.listStrategies();
+      await Promise.all(
+        list.map(async (s: any) => {
+          try {
+            const res = await this.api.getStrategySummary(
+              s.id,
+              this.exchange,
+              this.category,
+              this.symbol,
+            );
+            s.report = res.report;
+            s.fills = res.fills;
+          } catch {
+            s.report = null;
+            s.fills = [];
+          }
+        }),
+      );
       this.items.set(list);
     } catch (err: any) {
       this.snack.open(`Failed to load strategies: ${err?.error?.error || err?.message || 'unknown'}`, 'OK', { duration: 2500 });


### PR DESCRIPTION
## Summary
- Add `/strategies/{id}/summary` backend endpoint combining report metrics and recent fills
- Extend `ApiService` with `getStrategySummary` helper
- Display key metrics and last fills for each strategy and improve detail page loading

## Testing
- `pytest`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68bb9640db90832d893ce5f73599768b