### PR TITLE
feat: add websocket logs service

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -15,6 +15,7 @@ from .routers import (
     strategy_export,
     trades,
     observability,
+    ws_logs,
 )
 
 app = FastAPI(title="Amadeus API (patch v12 mega)")
@@ -54,6 +55,7 @@ app.include_router(bots.router, prefix="/api")
 app.include_router(strategy_analytics.router, prefix="/api")
 app.include_router(strategy_export.router, prefix="/api")
 app.include_router(observability.router, prefix="/api")
+app.include_router(ws_logs.router, prefix="/api")
 
 
 @app.get("/healthz")

--- a/backend/api/routers/ws_logs.py
+++ b/backend/api/routers/ws_logs.py
@@ -1,0 +1,8 @@
+from fastapi import APIRouter, WebSocket
+from .observability import ws_logs as _ws_logs
+
+router = APIRouter()
+
+@router.websocket("/ws/logs")
+async def ws_logs(ws: WebSocket):
+    await _ws_logs(ws)

--- a/frontend/src/app/core/services/ws.service.ts
+++ b/frontend/src/app/core/services/ws.service.ts
@@ -1,91 +1,63 @@
 import { Injectable } from '@angular/core';
-import { Subject, interval, takeUntil } from 'rxjs';
+import { Subject, BehaviorSubject } from 'rxjs';
 import { environment } from '../../../environments/environment';
 
 @Injectable({ providedIn: 'root' })
 export class WsService {
   private socket?: WebSocket;
-  private stop$ = new Subject<void>();
   private baseOverride?: string;
 
   public messages$ = new Subject<any>();
   public stream$ = new Subject<Event>();
+  public errors$ = new Subject<any>();
+  public status$ = new BehaviorSubject<'disconnected' | 'connecting' | 'connected' | 'error'>('disconnected');
+
+  private computeBase(url?: string): string {
+    return String(url || 'http://127.0.0.1:8100/api')
+      .replace(/\/$/, '')
+      .replace(/^http/, 'ws') + '/ws';
+  }
 
   private get baseUrl(): string {
-    if (this.baseOverride) return this.baseOverride;
-
-    return String((environment as any).api || 'http://127.0.0.1:8100/api')
-      .replace(/\/$/, '')
-      .replace(/^http/, 'ws')
-      .replace(/\/api(?:\/.*)?$/, '/api/ws/');
+    return this.baseOverride || this.computeBase((environment as any).api);
   }
 
   setBaseUrl(url: string) {
-    this.baseOverride = url
-      ? String(url)
-          .replace(/\/$/, '')
-          .replace(/^http/, 'ws')
-          .replace(/\/api(?:\/.*)?$/, '/api/ws/')
-      : undefined;
+    this.baseOverride = url ? this.computeBase(url) : undefined;
   }
 
-  connect(channel: string = ''): WebSocket | undefined {
-    this.stop$.next();
-
-    if ((environment as any).demo) {
-      queueMicrotask(() => this.stream$.next(new Event('open')));
-      let last = 50000;
-      interval(800).pipe(takeUntil(this.stop$)).subscribe(() => {
-        const chg = (Math.random() - 0.5) * 20;
-        last = Math.max(100, last + chg);
-        const msg = {
-          type: 'trade',
-          symbol: 'BTCUSDT',
-          ts: Date.now(),
-          side: chg >= 0 ? 'buy' : 'sell',
-          price: +last.toFixed(2),
-          qty: +(Math.random() * 0.5 + 0.01).toFixed(3),
-        };
-        this.messages$.next(msg);
-      });
-      return undefined;
-    }
-
-    // reset subjects on reconnect so errors propagate again
-    if (this.messages$.isStopped) this.messages$ = new Subject<any>();
-    if (this.stream$.isStopped) this.stream$ = new Subject<Event>();
-
-    const url = this.baseUrl + channel;
-
+  connect(channel = ''): WebSocket | undefined {
     if (this.socket) {
-      try {
-        this.socket.close();
-      } catch {}
+      try { this.socket.close(); } catch {}
+      this.socket = undefined;
     }
 
+    const url = `${this.baseUrl.replace(/\/$/, '')}${channel ? '/' + channel.replace(/^\//, '') : ''}`;
     let ws: WebSocket;
     try {
       ws = new WebSocket(url);
     } catch (err) {
-      this.stream$.error(err as any);
-      this.messages$.error(err);
+      this.status$.next('error');
+      this.errors$.next(err);
       return undefined;
     }
     this.socket = ws;
+    this.status$.next('connecting');
 
-    ws.onopen = (evt) => this.stream$.next(evt);
-    ws.onclose = (evt) => {
-      if (evt.wasClean) this.stream$.next(evt);
-      else {
-        this.stream$.error(evt as any);
-        this.messages$.error(new Error(`WebSocket closed: ${evt.code}`));
-      }
+    ws.onopen = evt => {
+      this.status$.next('connected');
+      this.stream$.next(evt);
     };
-    ws.onerror = (evt) => {
-      this.stream$.error(evt as any);
-      this.messages$.error(new Error('Connection lost. Please retry.'));
+    ws.onclose = evt => {
+      this.status$.next('disconnected');
+      this.stream$.next(evt);
     };
-    ws.onmessage = (evt) => {
+    ws.onerror = evt => {
+      this.status$.next('error');
+      this.errors$.next(evt);
+      this.stream$.next(evt);
+    };
+    ws.onmessage = evt => {
       this.stream$.next(evt);
       try {
         this.messages$.next(JSON.parse(evt.data));
@@ -98,19 +70,18 @@ export class WsService {
   }
 
   send(obj: any) {
-    if ((environment as any).demo) return;
     if (this.socket && this.socket.readyState === WebSocket.OPEN) {
       this.socket.send(typeof obj === 'string' ? obj : JSON.stringify(obj));
     }
   }
 
   close() {
-    this.stop$.next();
     if (this.socket) {
       try {
         this.socket.close();
       } finally {
         this.socket = undefined;
+        this.status$.next('disconnected');
       }
     }
   }


### PR DESCRIPTION
## Summary
- derive ws base URL from environment.api and expose connection errors
- show websocket status and messages on logs page
- provide backend websocket stub at /api/ws/logs

## Testing
- `npm run build`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb975d95a8832dbf866e904e722a0a