### PR TITLE
Use bot endpoints for strategy control

### DIFF
--- a/frontend/src/app/core/services/api.service.ts
+++ b/frontend/src/app/core/services/api.service.ts
@@ -90,16 +90,6 @@ export class ApiService {
     return firstValueFrom(this.http.get(url, { headers: this.headers() }));
   }
 
-  startStrategy(id: string, cfg: any) {
-    const url = this.url(`/strategies/${id}/start`);
-    return firstValueFrom(this.http.post(url, cfg, { headers: this.headers() }));
-  }
-
-  stopStrategy(id: string) {
-    const url = this.url(`/strategies/${id}/stop`);
-    return firstValueFrom(this.http.post(url, {}, { headers: this.headers() }));
-  }
-
   async getStrategyReport(
     id: string,
     exchange: string,

--- a/frontend/src/app/features/strategies/strategies.component.ts
+++ b/frontend/src/app/features/strategies/strategies.component.ts
@@ -46,6 +46,14 @@ import { firstValueFrom } from 'rxjs';
               }
             </select>
           </div>
+          <div>
+            <label class="block text-sm mb-1">Exchange</label>
+            <input class="border rounded p-2 w-full" [(ngModel)]="exchange" />
+          </div>
+          <div>
+            <label class="block text-sm mb-1">Symbol</label>
+            <input class="border rounded p-2 w-full" [(ngModel)]="symbol" />
+          </div>
           <div class="col-span-2">
             <app-json-schema-form [schema]="schema()" [(model)]="cfg"></app-json-schema-form>
           </div>
@@ -66,6 +74,8 @@ export class StrategiesComponent {
   cfg: any = {};
   schema = signal<any>({type:'object', properties:{}});
   api = inject(ApiService);
+  exchange = 'mock';
+  symbol = '';
 
   async ngOnInit() {
     await this.refresh();
@@ -114,7 +124,12 @@ export class StrategiesComponent {
   async create() {
     if (!this.sid) return;
     try {
-      await this.api.startStrategy(this.sid, this.cfg);
+      await this.api.startBot({
+        strategy_id: this.sid,
+        exchange: this.exchange,
+        symbol: this.symbol,
+        ...this.cfg,
+      });
       this.openCreate = false;
       await this.refresh();
     } catch (err:any) {


### PR DESCRIPTION
## Summary
- remove unused start/stop strategy API methods
- start and stop bots from strategy components using exchange and symbol
- refresh strategy lists after bot actions

## Testing
- `npm test --prefix frontend` *(fails: Missing script: "test")*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb9d1bc2f8832da0269a8141f7df81