### PR TITLE
Expand CORS configuration to allow all methods and headers

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -33,8 +33,8 @@ def api_status():
 
 # Configure CORS settings from environment or defaults
 ALLOWED_ORIGINS = os.getenv("CORS_ALLOW_ORIGINS", "http://localhost:4400").split(",")
-ALLOWED_METHODS = ["GET", "POST"]
-ALLOWED_HEADERS = ["Content-Type"]
+ALLOWED_METHODS = ["*"]
+ALLOWED_HEADERS = ["*"]
 
 app.add_middleware(
     CORSMiddleware,


### PR DESCRIPTION
## Summary
- allow all HTTP methods and headers in API CORS configuration

## Testing
- `pytest -q`
- `uvicorn backend.api.main:app --port 8001` (start server and exit)


------
https://chatgpt.com/codex/tasks/task_e_68bb9cf5c930832d97a61c77e814b4e5