### PR TITLE
Ensure strategy selectors use valid IDs and handle missing strategy data

### DIFF
--- a/frontend/src/app/features/strategies/strategies-modern.component.ts
+++ b/frontend/src/app/features/strategies/strategies-modern.component.ts
@@ -37,6 +37,7 @@ import { ApiService } from '../../core/services/api.service';
         <div class="font-medium">Last Fills</div>
         <div *ngFor="let f of s.fills">{{ f.side }} {{ f.qty }} @ {{ f.price }}</div>
       </div>
+      <div class="text-xs text-red-600 mt-2" *ngIf="s.error">{{ s.error }}</div>
       <div class="flex items-center gap-3 mt-3">
         <button class="btn" title="Edit" (click)="edit.emit(s.id); $event.preventDefault(); $event.stopPropagation()">⚙</button>
         <button class="btn" title="Delete" (click)="remove.emit(s.id); $event.preventDefault(); $event.stopPropagation()">🗑</button>
@@ -55,7 +56,7 @@ export class StrategiesModernComponent implements OnInit {
   @Output() edit = new EventEmitter<string>();
   @Output() remove = new EventEmitter<string>();
 
-  items = signal<{id: string; running: boolean; report?: any; fills?: any[]}[]>([]);
+  items = signal<{id: string; running: boolean; report?: any; fills?: any[]; error?: string}[]>([]);
   exchange = 'binance';
   category = 'usdt';
   symbol = 'BTCUSDT';
@@ -78,9 +79,11 @@ export class StrategiesModernComponent implements OnInit {
             );
             s.report = res.report;
             s.fills = res.fills;
+            s.error = null;
           } catch {
             s.report = null;
             s.fills = [];
+            s.error = 'Data not available';
           }
         }),
       );

--- a/frontend/src/app/features/strategy-detail/strategy-detail.component.ts
+++ b/frontend/src/app/features/strategy-detail/strategy-detail.component.ts
@@ -70,26 +70,29 @@ export class StrategyDetailComponent {
 
   async load() {
     this.error.set(null);
-    const [repRes, fillRes] = await Promise.all([
-      this.api
-        .getStrategyReport(this.sid, this.exchange, this.category, this.symbol)
-        .catch((e) => {
-          console.error('Failed to load strategy report', e);
-          this.error.set('Report not available');
-          return { report: {} } as any;
-        }),
-      this.api
-        .getStrategyFills(this.sid, this.exchange, this.category, this.symbol)
-        .catch((e) => {
-          console.error('Failed to load strategy fills', e);
-          this.error.update((msg) =>
-            msg ? msg + '; fills not available' : 'Fills not available',
-          );
-          return { items: [] } as any;
-        }),
-    ]);
-    this.rep.set(repRes.report || {});
-    this.fills.set(fillRes.items || []);
+    try {
+      const [repRes, fillRes] = await Promise.all([
+        this.api.getStrategyReport(
+          this.sid,
+          this.exchange,
+          this.category,
+          this.symbol,
+        ),
+        this.api.getStrategyFills(
+          this.sid,
+          this.exchange,
+          this.category,
+          this.symbol,
+        ),
+      ]);
+      this.rep.set(repRes.report || {});
+      this.fills.set(fillRes.items || []);
+    } catch (e) {
+      console.error('Failed to load strategy data', e);
+      this.error.set('Data not available');
+      this.rep.set({});
+      this.fills.set([]);
+    }
   }
 
   csvUrl() {

--- a/frontend/src/app/features/trades/trades.component.ts
+++ b/frontend/src/app/features/trades/trades.component.ts
@@ -15,7 +15,9 @@ import { firstValueFrom } from 'rxjs';
       <input class="border rounded p-2 w-full" [(ngModel)]="symbol" placeholder="symbol (e.g. BTCUSDT)">
       <input class="border rounded p-2 w-full" [(ngModel)]="exchange" placeholder="exchange (binance/bybit)">
       <input class="border rounded p-2 w-full" [(ngModel)]="category" placeholder="category (spot/usdt/linear)">
-      <input class="border rounded p-2 w-full" [(ngModel)]="strategy_id" placeholder="strategy id">
+      <select class="border rounded p-2 w-full" [(ngModel)]="strategy_id">
+        <option *ngFor="let s of strategies" [value]="s.id">{{ s.id }}</option>
+      </select>
       <button class="px-3 py-2 rounded bg-black text-white" (click)="load()">Load</button>
     </div>
     <div class="mb-3">
@@ -35,7 +37,23 @@ import { firstValueFrom } from 'rxjs';
 export class TradesComponent {
   api = inject(ApiService);
   symbol=''; exchange=''; category=''; strategy_id='';
+  strategies: {id: string; running: boolean}[] = [];
   items = signal<any[]>([]);
+
+  async ngOnInit() {
+    await this.loadStrategies();
+  }
+
+  private async loadStrategies() {
+    try {
+      this.strategies = await this.api.listStrategies();
+      if (!this.strategy_id && this.strategies.length) {
+        this.strategy_id = this.strategies[0].id;
+      }
+    } catch (err) {
+      console.error('Failed to load strategies', err);
+    }
+  }
   async load() {
     const params = new URLSearchParams();
     if (this.symbol) params.set('symbol', this.symbol);

--- a/frontend/src/app/pages/dashboard.page.ts
+++ b/frontend/src/app/pages/dashboard.page.ts
@@ -42,7 +42,9 @@ import { ApiService } from '../core/services/api.service';
         <div class="grid gap-3">
           <div>
             <label class="block text-sm mb-1">Strategy</label>
-            <input class="border rounded p-2 w-full" [(ngModel)]="strategy_id" />
+            <select class="border rounded p-2 w-full" [(ngModel)]="strategy_id">
+              <option *ngFor="let s of strategies" [value]="s.id">{{ s.id }}</option>
+            </select>
           </div>
           <div>
             <label class="block text-sm mb-1">Exchange</label>
@@ -72,6 +74,7 @@ export class DashboardPage implements OnInit {
   openAdd = false;
 
   strategy_id = '';
+  strategies: {id: string; running: boolean}[] = [];
   exchange = 'mock';
   symbol = '';
   risk = '';
@@ -83,6 +86,14 @@ export class DashboardPage implements OnInit {
   async refresh() {
     const res = await this.api.listBots();
     this.bots = res.items ?? [];
+    try {
+      this.strategies = await this.api.listStrategies();
+      if (!this.strategy_id && this.strategies.length) {
+        this.strategy_id = this.strategies[0].id;
+      }
+    } catch (err) {
+      console.error('Failed to load strategies', err);
+    }
   }
 
   async start() {


### PR DESCRIPTION
## Summary
- Populate strategy selectors via ApiService.listStrategies so users choose only valid IDs
- Gracefully handle getStrategySummary/getStrategyReport/getStrategyFills failures with friendly 'Data not available' message
- Expose strategy-loading logic across components and show errors per strategy card

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68bb9e9c6b88832d93d0045eab4e472f