### PR TITLE
Add status, dashboard summary, and history routers

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -1,7 +1,6 @@
 import os
-import time
 
-from fastapi import APIRouter, FastAPI
+from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from backend.observability import router as observability_router
@@ -16,20 +15,12 @@ from .routers import (
     trades,
     observability,
     ws_logs,
+    dashboard,
+    history,
+    status,
 )
 
 app = FastAPI(title="Amadeus API (patch v12 mega)")
-START_TIME = time.time()
-
-status_router = APIRouter()
-
-
-@status_router.get("/status")
-def api_status():
-    """Return basic health information with uptime and version."""
-    uptime = time.time() - START_TIME
-    version = os.getenv("APP_VERSION", "dev")
-    return {"ok": True, "uptime": uptime, "version": version}
 
 # Configure CORS settings from environment or defaults
 ALLOWED_ORIGINS = os.getenv("CORS_ALLOW_ORIGINS", "http://localhost:4400").split(",")
@@ -44,7 +35,9 @@ app.add_middleware(
     allow_headers=ALLOWED_HEADERS,
 )
 
-app.include_router(status_router, prefix="/api")
+app.include_router(status.router, prefix="/api")
+app.include_router(dashboard.router, prefix="/api")
+app.include_router(history.router, prefix="/api")
 app.include_router(observability_router, prefix="/api")
 app.include_router(trades.router, prefix="/api")
 app.include_router(risk_ext.router, prefix="/api")

--- a/backend/api/routers/history.py
+++ b/backend/api/routers/history.py
@@ -1,0 +1,48 @@
+from fastapi import APIRouter, Depends
+from sqlmodel import Session, select
+
+from backend.core.db import get_session
+from backend.core.models import OrderRow, FillRow
+
+router = APIRouter(prefix="/history", tags=["history"])
+
+
+@router.get("/orders")
+def order_history(limit: int = 100, offset: int = 0, session: Session = Depends(get_session)):
+    stmt = select(OrderRow).order_by(OrderRow.id.desc()).offset(offset).limit(limit)
+    rows = session.exec(stmt).all()
+    items = [
+        {
+            "id": r.id,
+            "ts": int(r.created_at.timestamp() * 1000) if r.created_at else None,
+            "event": r.status,
+            "symbol": r.symbol,
+            "side": r.side,
+            "type": "limit" if r.price is not None else "market",
+            "price": r.price,
+            "qty": r.qty,
+            "status": r.status,
+        }
+        for r in rows
+    ]
+    return {"items": items}
+
+
+@router.get("/trades")
+def trade_history(limit: int = 100, offset: int = 0, session: Session = Depends(get_session)):
+    stmt = select(FillRow).order_by(FillRow.id.desc()).offset(offset).limit(limit)
+    rows = session.exec(stmt).all()
+    items = [
+        {
+            "id": r.id,
+            "ts": r.ts,
+            "type": "fill",
+            "symbol": r.symbol,
+            "side": r.side,
+            "price": r.price,
+            "qty": r.qty,
+            "pnl": r.meta.get("pnl") if isinstance(r.meta, dict) else None,
+        }
+        for r in rows
+    ]
+    return {"items": items}

--- a/backend/api/routers/status.py
+++ b/backend/api/routers/status.py
@@ -1,0 +1,15 @@
+import os
+import time
+from fastapi import APIRouter
+
+router = APIRouter(tags=["status"])
+
+_START_TIME = time.time()
+
+
+@router.get("/status")
+def api_status():
+    """Return basic health information with uptime and version."""
+    uptime = time.time() - _START_TIME
+    version = os.getenv("APP_VERSION", "dev")
+    return {"ok": True, "uptime": uptime, "version": version}


### PR DESCRIPTION
## Summary
- add dedicated `/status` health endpoint
- expose `/dashboard/summary` and `/history/{orders,trades}` via new routers
- register new routers with the API application

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bba2ed9274832d808c3f5826d315b0