### PR TITLE
Ensure proper log stream connection handling

### DIFF
--- a/frontend/src/app/core/services/ws.service.ts
+++ b/frontend/src/app/core/services/ws.service.ts
@@ -13,9 +13,10 @@ export class WsService {
   public status$ = new BehaviorSubject<'disconnected' | 'connecting' | 'connected' | 'error'>('disconnected');
 
   private computeBase(url?: string): string {
-    return String(url || 'http://127.0.0.1:8100/api')
+    const root = String(url || 'http://127.0.0.1:8100')
       .replace(/\/$/, '')
-      .replace(/^http/, 'ws') + '/ws';
+      .replace(/\/api$/, '');
+    return root.replace(/^http/, 'ws') + '/api/ws';
   }
 
   private get baseUrl(): string {

--- a/frontend/src/app/pages/logs.page.ts
+++ b/frontend/src/app/pages/logs.page.ts
@@ -55,8 +55,8 @@ export class LogsPage {
     });
 
     this.statusSub = this.ws.status$.subscribe(s => this.status = s);
-    this.errSub = this.ws.errors$.subscribe(err => {
-      this.lines.push(err?.message || 'WebSocket connection failed');
+    this.errSub = this.ws.errors$.subscribe(() => {
+      this.lines.push('Log stream unavailable');
       setTimeout(() => this.scrollBottom());
     });
     this.msgSub = this.ws.messages$.subscribe((msg: any) => {
@@ -72,7 +72,7 @@ export class LogsPage {
     this.status = 'connecting';
     const ws = this.ws.connect('logs');
     if (!ws) {
-      this.lines.push('Failed to connect to log stream.');
+      this.lines.push('Log stream unavailable');
       setTimeout(() => this.scrollBottom());
     }
   }


### PR DESCRIPTION
## Summary
- guarantee websocket base URLs include `/api/ws` before appending channels
- show "Log stream unavailable" when websocket connection fails

## Testing
- `npm test` *(fails: Missing script "test")*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bba3ee7da0832da6bee7cfd8b9c322