### PR TITLE
refactor: remove legacy start-stop endpoints

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -84,11 +84,18 @@ export class DashboardComponent implements OnDestroy {
     );
   }
 
-  panicSell() {
+  async panicSell() {
     if (!window.confirm('Выполнить PANIC SELL?')) return;
-    this.api.cmd('x').subscribe({
-      next: _ => this.snack.open('Panic sell executed', 'OK', { duration: 2000 }),
-      error: err => this.snack.open(`Ошибка: ${err?.error?.error || err?.message || 'unknown'}`, 'OK', { duration: 2500 })
-    });
+    const id = this.cfg?.id || this.cfg?.botId || this.cfg?.bot_id;
+    if (!id) {
+      this.snack.open('No active bot', 'OK', { duration: 2000 });
+      return;
+    }
+    try {
+      await this.api.stopBot(id);
+      this.snack.open('Panic sell executed', 'OK', { duration: 2000 });
+    } catch (err: any) {
+      this.snack.open(`Ошибка: ${err?.error?.error || err?.message || 'unknown'}`, 'OK', { duration: 2500 });
+    }
   }
 }

--- a/frontend/src/app/core/services/api.service.ts
+++ b/frontend/src/app/core/services/api.service.ts
@@ -45,10 +45,9 @@ export class ApiService {
   running$ = new BehaviorSubject<boolean>(false);
   setRunning(v: boolean) { this.running$.next(!!v); }
 
-  // status endpoint not available yet
-  start(body?: any) { return this.post('/start', body ?? {}); }
-  stop()  { return this.post('/stop', {}); }
-  cmd(command: string, payload: any = {}) { return this.post('/cmd', { cmd: command, ...payload }); }
+  getLogs(limit = 100) {
+    return this.get<{lines: string[]}>(`/observability/logs?limit=${limit}`);
+  }
 
   getConfig()         { return this.get('/config'); }
   putConfig(cfg: any) { return this.put('/config', cfg); }

--- a/frontend/src/app/interceptors/demo-api.interceptor.ts
+++ b/frontend/src/app/interceptors/demo-api.interceptor.ts
@@ -16,9 +16,9 @@ export const demoApiInterceptor: HttpInterceptorFn = (req: HttpRequest<any>, nex
   if (method === 'GET' && url.endsWith('/status')) {
     return of(json({ ok: true, running: true, ts: Date.now(), version: 'v0.1.0-demo' })).pipe(delay(lag));
   }
-  if (method === 'POST' && url.endsWith('/start')) return of(json({ ok: true, started: true })).pipe(delay(lag));
-  if (method === 'POST' && url.endsWith('/stop'))  return of(json({ ok: true, stopped: true })).pipe(delay(lag));
-  if (method === 'POST' && url.endsWith('/cmd'))   return of(json({ ok: true, result: 'ack' })).pipe(delay(lag));
+  if (method === 'GET' && url.startsWith('/observability/logs')) {
+    return of(json({ lines: ['demo log line'] })).pipe(delay(lag));
+  }
 
   if (method === 'GET' && url.endsWith('/config')) {
     return of(json({

--- a/frontend/src/app/pages/logs.page.ts
+++ b/frontend/src/app/pages/logs.page.ts
@@ -36,13 +36,11 @@ export class LogsPage {
   constructor(private ws: WsService, private api: ApiService) {}
 
   ngOnInit() {
-    this.api.cmd('logs').subscribe({
+    this.api.getLogs().subscribe({
       next: (res: any) => {
-        const arr = Array.isArray(res?.logs)
-          ? res.logs
-          : typeof res === 'string'
-            ? [res]
-            : [];
+        const arr = Array.isArray(res?.lines)
+          ? res.lines
+          : [];
         if (arr.length) {
           this.lines.push(...arr.map((l: any) => String(l)));
           setTimeout(() => this.scrollBottom());


### PR DESCRIPTION
## Summary
- drop obsolete start/stop/cmd methods and add `getLogs`
- switch controls, dashboard panic, and logs page to bot API & observability logs
- clean demo API interceptor and ensure no requests use removed endpoints

## Testing
- `pytest`
- `npm run build` *(fails: Could not resolve "@primeng/themes/aura")*

------
https://chatgpt.com/codex/tasks/task_e_68bba82086d0832dbce346bbf04b4644