### PR TITLE
feat: link strategy logs

### DIFF
--- a/frontend/src/app/features/strategies/strategies-modern.component.ts
+++ b/frontend/src/app/features/strategies/strategies-modern.component.ts
@@ -1,6 +1,6 @@
 import { Component, EventEmitter, OnInit, Output, inject, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { RouterModule } from '@angular/router';
+import { Router, RouterModule } from '@angular/router';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { AppMaterialModule } from '../../app.module';
 import { ApiService } from '../../core/services/api.service';
@@ -41,7 +41,7 @@ import { ApiService } from '../../core/services/api.service';
       <div class="flex items-center gap-3 mt-3">
         <button class="btn" title="Edit" (click)="edit.emit(s.id); $event.preventDefault(); $event.stopPropagation()">⚙</button>
         <button class="btn" title="Delete" (click)="remove.emit(s.id); $event.preventDefault(); $event.stopPropagation()">🗑</button>
-        <button class="btn" title="Logs" (click)="$event.preventDefault(); $event.stopPropagation()">🧾</button>
+        <button class="btn" title="Logs" (click)="showLogs(s.id); $event.preventDefault(); $event.stopPropagation()">🧾</button>
       </div>
     </a>
   </div>
@@ -50,6 +50,7 @@ import { ApiService } from '../../core/services/api.service';
 export class StrategiesModernComponent implements OnInit {
   private api = inject(ApiService);
   private snack = inject(MatSnackBar);
+  private router = inject(Router);
 
   @Output() create = new EventEmitter<void>();
   @Output() importCfg = new EventEmitter<void>();
@@ -91,5 +92,9 @@ export class StrategiesModernComponent implements OnInit {
     } catch (err: any) {
       this.snack.open(`Failed to load strategies: ${err?.error?.error || err?.message || 'unknown'}`, 'OK', { duration: 2500 });
     }
+  }
+
+  showLogs(id: string) {
+    this.router.navigate(['/logs'], { queryParams: { sid: id } });
   }
 }

--- a/frontend/src/app/pages/logs.page.ts
+++ b/frontend/src/app/pages/logs.page.ts
@@ -4,6 +4,7 @@ import { FormsModule } from '@angular/forms';
 import { Subscription } from 'rxjs';
 import { WsService } from '../core/services/ws.service';
 import { ApiService } from '../core/services/api.service';
+import { ActivatedRoute } from '@angular/router';
 
 @Component({
   selector: 'app-logs',
@@ -33,9 +34,12 @@ export class LogsPage {
   private errSub?: Subscription;
   private statusSub?: Subscription;
 
-  constructor(private ws: WsService, private api: ApiService) {}
+  constructor(private ws: WsService, private api: ApiService, private route: ActivatedRoute) {}
 
   ngOnInit() {
+    const sid = this.route.snapshot.queryParamMap.get('sid');
+    if (sid) this.filter = sid;
+
     this.api.getLogs().subscribe({
       next: (res: any) => {
         const arr = Array.isArray(res?.lines)


### PR DESCRIPTION
## Summary
- enable navigating to logs for specific strategy
- filter logs page using sid query parameter

## Testing
- `npm --prefix frontend run build` *(fails: Could not resolve "@primeng/themes/aura")*
- `pytest` *(fails: No module named 'pydantic_settings')*

------
https://chatgpt.com/codex/tasks/task_e_68bba987314c832d9aab3d67a5fa87d6