### PR TITLE
Use environment-defined websocket URL

### DIFF
--- a/frontend/src/app/core/services/ws.service.ts
+++ b/frontend/src/app/core/services/ws.service.ts
@@ -13,14 +13,13 @@ export class WsService {
   public status$ = new BehaviorSubject<'disconnected' | 'connecting' | 'connected' | 'error'>('disconnected');
 
   private computeBase(url?: string): string {
-    const root = String(url || 'http://127.0.0.1:8100')
+    return String(url || 'http://127.0.0.1:8100/api/ws')
       .replace(/\/$/, '')
-      .replace(/\/api$/, '');
-    return root.replace(/^http/, 'ws') + '/api/ws';
+      .replace(/^http/, 'ws');
   }
 
   private get baseUrl(): string {
-    return this.baseOverride || this.computeBase((environment as any).api);
+    return this.baseOverride || this.computeBase((environment as any).ws);
   }
 
   setBaseUrl(url: string) {

--- a/frontend/src/environments/environment.ts
+++ b/frontend/src/environments/environment.ts
@@ -2,6 +2,6 @@ export const environment = {
   production: false,
   demo: false,
   api: 'http://127.0.0.1:8100/api',
-  ws:  'ws://127.0.0.1:8100/ws',
+  ws:  'ws://127.0.0.1:8100/api/ws',
   token: ''
 };


### PR DESCRIPTION
## Summary
- point development `ws` configuration to `ws://127.0.0.1:8100/api/ws`
- compute websocket base from `environment.ws` without appending extra segments

## Testing
- `npm run build`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bbaa908400832db0df29048067a835