### PR TITLE
Handle missing strategy IDs before summary

### DIFF
--- a/frontend/src/app/features/strategies/strategies-modern.component.ts
+++ b/frontend/src/app/features/strategies/strategies-modern.component.ts
@@ -18,32 +18,43 @@ import { ApiService } from '../../core/services/api.service';
     </div>
   </div>
   <div class="grid lg:grid-cols-3 gap-3">
-    <a class="card p-4 block" *ngFor="let s of items()" [routerLink]="['/strategies', s.id]">
-      <div class="flex items-center justify-between">
-        <div class="font-medium">{{ s.id }}</div>
-        <span class="badge" [class.ok]="s.running" [class.err]="!s.running">{{ s.running ? 'running' : 'stopped' }}</span>
-      </div>
-      <div class="grid grid-cols-2 gap-1 text-xs mt-3" *ngIf="s.report">
-        <div>Sharpe: {{ s.report.sharpe | number:'1.2-2' }}</div>
-        <div>Sortino: {{ s.report.sortino | number:'1.2-2' }}</div>
-        <div>Calmar: {{ s.report.calmar | number:'1.2-2' }}</div>
-        <div>Max DD: {{ s.report.maxdd | percent:'1.0-2' }}</div>
-        <div>Win Rate: {{ s.report.winrate | percent:'1.0-0' }}</div>
-        <div>Profit Factor: {{ s.report.profit_factor | number:'1.2-2' }}</div>
-        <div>CAGR: {{ s.report.cagr | percent:'1.2-2' }}</div>
-        <div>PnL: {{ s.report.pnl_total | number:'1.2-2' }}</div>
-      </div>
-      <div class="mt-2 text-xs" *ngIf="s.fills?.length">
-        <div class="font-medium">Last Fills</div>
-        <div *ngFor="let f of s.fills">{{ f.side }} {{ f.qty }} @ {{ f.price }}</div>
-      </div>
-      <div class="text-xs text-red-600 mt-2" *ngIf="s.error">{{ s.error }}</div>
-      <div class="flex items-center gap-3 mt-3">
-        <button class="btn" title="Edit" (click)="edit.emit(s.id); $event.preventDefault(); $event.stopPropagation()">⚙</button>
-        <button class="btn" title="Delete" (click)="remove.emit(s.id); $event.preventDefault(); $event.stopPropagation()">🗑</button>
-        <button class="btn" title="Logs" (click)="showLogs(s.id); $event.preventDefault(); $event.stopPropagation()">🧾</button>
-      </div>
-    </a>
+    <ng-container *ngFor="let s of items()">
+      <a *ngIf="s.error !== 'Strategy not found'; else missing" class="card p-4 block" [routerLink]="['/strategies', s.id]">
+        <div class="flex items-center justify-between">
+          <div class="font-medium">{{ s.id }}</div>
+          <span class="badge" [class.ok]="s.running" [class.err]="!s.running">{{ s.running ? 'running' : 'stopped' }}</span>
+        </div>
+        <div class="grid grid-cols-2 gap-1 text-xs mt-3" *ngIf="s.report">
+          <div>Sharpe: {{ s.report.sharpe | number:'1.2-2' }}</div>
+          <div>Sortino: {{ s.report.sortino | number:'1.2-2' }}</div>
+          <div>Calmar: {{ s.report.calmar | number:'1.2-2' }}</div>
+          <div>Max DD: {{ s.report.maxdd | percent:'1.0-2' }}</div>
+          <div>Win Rate: {{ s.report.winrate | percent:'1.0-0' }}</div>
+          <div>Profit Factor: {{ s.report.profit_factor | number:'1.2-2' }}</div>
+          <div>CAGR: {{ s.report.cagr | percent:'1.2-2' }}</div>
+          <div>PnL: {{ s.report.pnl_total | number:'1.2-2' }}</div>
+        </div>
+        <div class="mt-2 text-xs" *ngIf="s.fills?.length">
+          <div class="font-medium">Last Fills</div>
+          <div *ngFor="let f of s.fills">{{ f.side }} {{ f.qty }} @ {{ f.price }}</div>
+        </div>
+        <div class="text-xs text-red-600 mt-2" *ngIf="s.error && s.error !== 'Strategy not found'">{{ s.error }}</div>
+        <div class="flex items-center gap-3 mt-3">
+          <button class="btn" title="Edit" (click)="edit.emit(s.id); $event.preventDefault(); $event.stopPropagation()">⚙</button>
+          <button class="btn" title="Delete" (click)="remove.emit(s.id); $event.preventDefault(); $event.stopPropagation()">🗑</button>
+          <button class="btn" title="Logs" (click)="showLogs(s.id); $event.preventDefault(); $event.stopPropagation()">🧾</button>
+        </div>
+      </a>
+      <ng-template #missing>
+        <div class="card p-4">
+          <div class="font-medium">{{ s.id || 'Unknown' }}</div>
+          <div class="text-xs text-red-600 mt-2">Strategy not found</div>
+          <div class="flex items-center gap-3 mt-3">
+            <button class="btn" (click)="create.emit()">Create</button>
+          </div>
+        </div>
+      </ng-template>
+    </ng-container>
   </div>
   `
 })
@@ -71,6 +82,12 @@ export class StrategiesModernComponent implements OnInit {
       const list = await this.api.listStrategies();
       await Promise.all(
         list.map(async (s: any) => {
+          if (!s?.id) {
+            s.report = null;
+            s.fills = [];
+            s.error = 'Strategy not found';
+            return;
+          }
           try {
             const res = await this.api.getStrategySummary(
               s.id,
@@ -81,10 +98,13 @@ export class StrategiesModernComponent implements OnInit {
             s.report = res.report;
             s.fills = res.fills;
             s.error = null;
-          } catch {
+          } catch (err: any) {
             s.report = null;
             s.fills = [];
-            s.error = 'Data not available';
+            s.error =
+              err?.status === 404 || err?.error?.error === 'Strategy not found'
+                ? 'Strategy not found'
+                : 'Data not available';
           }
         }),
       );


### PR DESCRIPTION
## Summary
- Avoid summary requests for missing strategy IDs
- Display "Strategy not found" with option to create missing strategies

## Testing
- `npm --prefix frontend run build` *(fails: Could not resolve "@primeng/themes/aura"; TS2307: Cannot find module '@primeng/themes/aura')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'pydantic_settings')*

------
https://chatgpt.com/codex/tasks/task_e_68bbac29e874832da6e7c5da09d3e4ab