### PR TITLE
Handle missing risk policies gracefully

### DIFF
--- a/backend/api/routers/risk.py
+++ b/backend/api/routers/risk.py
@@ -7,6 +7,10 @@ from backend.core.risk import RISK_ENGINE
 
 router = APIRouter(prefix="/risk", tags=["risk"])
 
+# Seed a default risk policy to avoid empty responses for the UI
+if not RISK_ENGINE.policies:
+    RISK_ENGINE.set_policy("default", max_active_orders=50, max_dd=0.5)
+
 # ---------------------------------------------------------------------------
 # Simple policy management used by tests
 # ---------------------------------------------------------------------------

--- a/frontend/src/app/pages/strategies.page.ts
+++ b/frontend/src/app/pages/strategies.page.ts
@@ -32,7 +32,7 @@ import { firstValueFrom } from 'rxjs';
           </div>
           <div>
             <label class="block text-sm mb-1">Risk Policy</label>
-            <select class="border rounded p-2 w-full" [(ngModel)]="riskPolicy">
+            <select class="border rounded p-2 w-full" [(ngModel)]="riskPolicy" [disabled]="!riskPolicies.length">
               <option *ngFor="let r of riskPolicies" [value]="r">{{ r }}</option>
             </select>
           </div>
@@ -188,7 +188,24 @@ export class StrategiesPage {
   }
 
   private async loadRiskPolicies() {
-    this.riskPolicies = await this.api.getRiskPolicies();
+    try {
+      this.riskPolicies = await this.api.getRiskPolicies();
+      if (!this.riskPolicies.length) {
+        this.snack.open('No risk policies found', 'OK', { duration: 2500 });
+      }
+    } catch (err: any) {
+      if (err?.status === 404) {
+        this.riskPolicies = [];
+        this.snack.open('No risk policies found', 'OK', { duration: 2500 });
+      } else {
+        this.riskPolicies = [];
+        this.snack.open(
+          `Load failed: ${err?.error?.error || err?.message || 'unknown'}`,
+          'OK',
+          { duration: 2500 },
+        );
+      }
+    }
     if (!this.riskPolicy && this.riskPolicies.length) {
       this.riskPolicy = this.riskPolicies[0];
     }


### PR DESCRIPTION
## Summary
- Handle missing risk policies in Strategies page by catching 404s and disabling selector
- Seed a default risk policy on the backend to avoid empty responses

## Testing
- `npm test` *(fails: Missing script: "test")*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bbae1c3754832db09bc7f75d053cf1