### PR TITLE
refactor: replace custom styles with PrimeNG components

### DIFF
--- a/frontend/src/app/components/controls/controls.component.html
+++ b/frontend/src/app/components/controls/controls.component.html
@@ -1,14 +1,8 @@
 <div class="controls">
     <div class="left">
-        <button class="btn primary"
-                (click)="doStart()" [disabled]="busy || running">
-            ▶︎ Старт
-        </button>
-        <button class="btn warn"
-                (click)="doStop()" [disabled]="busy || !running">
-            ■ Стоп
-        </button>
-        <button class="btn" (click)="refresh()" [disabled]="busy">Обновить</button>
+        <p-button label="▶︎ Старт" (onClick)="doStart()" [disabled]="busy || running" severity="primary"></p-button>
+        <p-button label="■ Стоп" (onClick)="doStop()" [disabled]="busy || !running" severity="warning"></p-button>
+        <p-button label="Обновить" (onClick)="refresh()" [disabled]="busy"></p-button>
     </div>
 
     <div class="right">

--- a/frontend/src/app/components/dashboard/dashboard.component.html
+++ b/frontend/src/app/components/dashboard/dashboard.component.html
@@ -51,6 +51,6 @@
 
 <div class="grid" style="margin-top:12px">
     <div class="cell" style="grid-column: span 3; text-align:center;">
-        <button class="btn warn" (click)="panicSell()" [disabled]="!running">PANIC SELL</button>
+        <p-button label="PANIC SELL" (onClick)="panicSell()" [disabled]="!running" severity="warning"></p-button>
     </div>
 </div>

--- a/frontend/src/app/components/history/history.component.html
+++ b/frontend/src/app/components/history/history.component.html
@@ -4,18 +4,18 @@
 <div class="row">
     <div>
         <b>Orders:</b> {{ stats?.orders ?? 0 }}
-        <button class="btn" (click)="refreshOrders()">Обновить</button>
-        <button class="btn" (click)="export('orders')">Export CSV</button>
-        <button class="btn warn" (click)="clear('orders')">Очистить</button>
+        <p-button label="Обновить" (onClick)="refreshOrders()" ></p-button>
+        <p-button label="Export CSV" (onClick)="export('orders')"></p-button>
+        <p-button label="Очистить" (onClick)="clear('orders')" severity="warning"></p-button>
     </div>
     <div>
         <b>Trades:</b> {{ stats?.trades ?? 0 }}
-        <button class="btn" (click)="refreshTrades()">Обновить</button>
-        <button class="btn" (click)="export('trades')">Export CSV</button>
-        <button class="btn warn" (click)="clear('trades')">Очистить</button>
+        <p-button label="Обновить" (onClick)="refreshTrades()"></p-button>
+        <p-button label="Export CSV" (onClick)="export('trades')"></p-button>
+        <p-button label="Очистить" (onClick)="clear('trades')" severity="warning"></p-button>
     </div>
     <div>
-        <button class="btn primary" (click)="clear('all')">Очистить всё</button>
+        <p-button label="Очистить всё" (onClick)="clear('all')" severity="primary"></p-button>
     </div>
 </div>
 

--- a/frontend/src/app/components/risk-widget/risk-widget.component.html
+++ b/frontend/src/app/components/risk-widget/risk-widget.component.html
@@ -2,8 +2,8 @@
     <div class="row">
         <div class="chip" [class.on]="data?.enabled">Risk: {{ data?.enabled ? 'ON' : 'OFF' }}</div>
         <div class="chip" [class.on]="data?.allowed">Entries: {{ data?.allowed ? 'ALLOWED' : 'BLOCKED' }}</div>
-        <button class="btn" (click)="refresh()">Обновить</button>
-        <button class="btn warn" (click)="unlock()">Снять блокировки</button>
+        <p-button label="Обновить" (onClick)="refresh()"></p-button>
+        <p-button label="Снять блокировки" (onClick)="unlock()" severity="warning"></p-button>
     </div>
 
     <div class="grid">

--- a/frontend/src/app/components/scanner/scanner.component.html
+++ b/frontend/src/app/components/scanner/scanner.component.html
@@ -8,7 +8,7 @@
     <label>Max pairs <input type="number" [(ngModel)]="cfg.max_pairs"></label>
     <label>Min spread bps <input type="number" [(ngModel)]="cfg.min_spread_bps"></label>
   </div>
-  <button class="btn" (click)="scan()" [disabled]="loading">{{ loading ? 'Scanning…' : 'Scan' }}</button>
+  <p-button (onClick)="scan()" [disabled]="loading" [label]="loading ? 'Scanning…' : 'Scan'"></p-button>
 </div>
 <div *ngIf="err" class="err">{{ err }}</div>
 

--- a/frontend/src/app/features/strategies/strategies-modern.component.ts
+++ b/frontend/src/app/features/strategies/strategies-modern.component.ts
@@ -10,19 +10,19 @@ import { ApiService } from '../../core/services/api.service';
   selector: 'app-strategies-modern',
   imports: [CommonModule, RouterModule, PrimeNgModule],
   template: `
-  <div class="flex items-center justify-between mb-4">
+    <div class="flex items-center justify-between mb-4">
     <h2 class="text-xl font-semibold">Strategies</h2>
     <div class="flex gap-2">
-      <button class="btn primary" title="Create new strategy (Ctrl+N)" (click)="create.emit()">New</button>
-      <button class="btn" title="Import config JSON" (click)="importCfg.emit()">Import</button>
+      <p-button label="New" (onClick)="create.emit()" severity="primary" title="Create new strategy (Ctrl+N)"></p-button>
+      <p-button label="Import" (onClick)="importCfg.emit()" title="Import config JSON"></p-button>
     </div>
   </div>
   <div class="grid lg:grid-cols-3 gap-3">
     <ng-container *ngFor="let s of items()">
-      <a *ngIf="s.error !== 'Strategy not found'; else missing" class="card p-4 block" [routerLink]="['/strategies', s.id]">
+      <p-card *ngIf="s.error !== 'Strategy not found'; else missing" class="p-4 block" [routerLink]="['/strategies', s.id]">
         <div class="flex items-center justify-between">
           <div class="font-medium">{{ s.id }}</div>
-          <span class="badge" [class.ok]="s.running" [class.err]="!s.running">{{ s.running ? 'running' : 'stopped' }}</span>
+          <p-badge [value]="s.running ? 'running' : 'stopped'" [severity]="s.running ? 'success' : 'danger'"></p-badge>
         </div>
         <div class="grid grid-cols-2 gap-1 text-xs mt-3" *ngIf="s.report">
           <div>Sharpe: {{ s.report.sharpe | number:'1.2-2' }}</div>
@@ -38,21 +38,21 @@ import { ApiService } from '../../core/services/api.service';
           <div class="font-medium">Last Fills</div>
           <div *ngFor="let f of s.fills">{{ f.side }} {{ f.qty }} @ {{ f.price }}</div>
         </div>
-        <div class="text-xs text-red-600 mt-2" *ngIf="s.error && s.error !== 'Strategy not found'">{{ s.error }}</div>
+        <div class="text-xs mt-2" *ngIf="s.error && s.error !== 'Strategy not found'">{{ s.error }}</div>
         <div class="flex items-center gap-3 mt-3">
-          <button class="btn" title="Edit" (click)="edit.emit(s.id); $event.preventDefault(); $event.stopPropagation()">⚙</button>
-          <button class="btn" title="Delete" (click)="remove.emit(s.id); $event.preventDefault(); $event.stopPropagation()">🗑</button>
-          <button class="btn" title="Logs" (click)="showLogs(s.id); $event.preventDefault(); $event.stopPropagation()">🧾</button>
+          <p-button label="⚙" (onClick)="edit.emit(s.id); $event.preventDefault(); $event.stopPropagation()" title="Edit"></p-button>
+          <p-button label="🗑" (onClick)="remove.emit(s.id); $event.preventDefault(); $event.stopPropagation()" title="Delete"></p-button>
+          <p-button label="🧾" (onClick)="showLogs(s.id); $event.preventDefault(); $event.stopPropagation()" title="Logs"></p-button>
         </div>
-      </a>
+      </p-card>
       <ng-template #missing>
-        <div class="card p-4">
+        <p-card class="p-4">
           <div class="font-medium">{{ s.id || 'Unknown' }}</div>
-          <div class="text-xs text-red-600 mt-2">Strategy not found</div>
+          <div class="text-xs mt-2">Strategy not found</div>
           <div class="flex items-center gap-3 mt-3">
-            <button class="btn" (click)="create.emit()">Create</button>
+            <p-button label="Create" (onClick)="create.emit()"></p-button>
           </div>
-        </div>
+        </p-card>
       </ng-template>
     </ng-container>
   </div>

--- a/frontend/src/app/home/home.component.html
+++ b/frontend/src/app/home/home.component.html
@@ -1,38 +1,38 @@
 <p-toast></p-toast>
 
 <section class="mx-auto max-w-6xl p-4 space-y-4">
-  <div class="card">
-    <div class="card-header">
-      <div class="flex items-center gap-2">
-        <i class="pi pi-table"></i>
-        <span class="uppercase">Dashboard</span>
+  <p-card>
+    <ng-template pTemplate="header">
+      <div class="flex items-center justify-between gap-2">
+        <div class="flex items-center gap-2">
+          <i class="pi pi-table"></i>
+          <span class="uppercase">Dashboard</span>
+        </div>
+        <div class="flex items-center gap-2">
+          <input pInputText placeholder="Search..." />
+          <p-button label="Ping UI" icon="pi pi-check" (onClick)="ping()" severity="primary"></p-button>
+        </div>
       </div>
-      <div class="flex items-center gap-2">
-        <input pInputText placeholder="Search..." class="px-3 py-1 rounded-lg bg-[#0f141a] border border-tvborder" />
-        <button pButton label="Ping UI" icon="pi pi-check" (click)="ping()" class="btn primary"></button>
-      </div>
-    </div>
-    <div class="card-body">
-      <p-table [value]="rows" styleClass="p-datatable-sm">
-        <ng-template pTemplate="header">
-          <tr>
-            <th>Symbol</th>
-            <th>Last Price</th>
-            <th>24h Volume</th>
-          </tr>
-        </ng-template>
-        <ng-template pTemplate="body" let-r>
-          <tr>
-            <td>{{ r.symbol }}</td>
-            <td>{{ r.price | number:'1.2-2' }}</td>
-            <td>{{ r.vol24h }}</td>
-          </tr>
-        </ng-template>
-      </p-table>
-    </div>
-  </div>
+    </ng-template>
+    <p-table [value]="rows" styleClass="p-datatable-sm">
+      <ng-template pTemplate="header">
+        <tr>
+          <th>Symbol</th>
+          <th>Last Price</th>
+          <th>24h Volume</th>
+        </tr>
+      </ng-template>
+      <ng-template pTemplate="body" let-r>
+        <tr>
+          <td>{{ r.symbol }}</td>
+          <td>{{ r.price | number:'1.2-2' }}</td>
+          <td>{{ r.vol24h }}</td>
+        </tr>
+      </ng-template>
+    </p-table>
+  </p-card>
 
-  <div class="rounded-xl border border-tvborder p-3 text-tvmuted">
-    <span class="badge">Tailwind v4 tokens live</span>
+  <div class="p-3">
+    <p-badge value="Tailwind v4 tokens live"></p-badge>
   </div>
 </section>

--- a/frontend/src/app/home/home.component.ts
+++ b/frontend/src/app/home/home.component.ts
@@ -5,11 +5,13 @@ import { MessageService } from 'primeng/api';
 import { ButtonModule } from 'primeng/button';
 import { TableModule } from 'primeng/table';
 import { InputTextModule } from 'primeng/inputtext';
+import { CardModule } from 'primeng/card';
+import { BadgeModule } from 'primeng/badge';
 
 @Component({
   selector: 'app-home',
   standalone: true,
-  imports: [CommonModule, ToastModule, ButtonModule, TableModule, InputTextModule],
+  imports: [CommonModule, ToastModule, ButtonModule, TableModule, InputTextModule, CardModule, BadgeModule],
   providers: [MessageService],
   templateUrl: './home.component.html',
   styleUrls: ['./home.component.css']

--- a/frontend/src/app/market/market.page.html
+++ b/frontend/src/app/market/market.page.html
@@ -1,5 +1,5 @@
 <div class="market">
-  <section class="chart card"><app-tv-lite-chart></app-tv-lite-chart></section>
-  <section class="orderbook card"><app-orderbook></app-orderbook></section>
-  <section class="trades card"><app-trades-virtual></app-trades-virtual></section>
+  <p-card class="chart"><app-tv-lite-chart></app-tv-lite-chart></p-card>
+  <p-card class="orderbook"><app-orderbook></app-orderbook></p-card>
+  <p-card class="trades"><app-trades-virtual></app-trades-virtual></p-card>
 </div>

--- a/frontend/src/app/market/market.page.ts
+++ b/frontend/src/app/market/market.page.ts
@@ -2,11 +2,12 @@ import { Component } from '@angular/core';
 import { TvLiteChartComponent } from './tv-lite-chart.component';
 import { OrderbookComponent } from './orderbook.component';
 import { TradesVirtualComponent } from './trades-virtual.component';
+import { CardModule } from 'primeng/card';
 
 @Component({
   selector: 'app-market',
   standalone: true,
-  imports: [TvLiteChartComponent, OrderbookComponent, TradesVirtualComponent],
+  imports: [TvLiteChartComponent, OrderbookComponent, TradesVirtualComponent, CardModule],
   templateUrl: './market.page.html',
   styleUrls: ['./market.page.scss']
 })

--- a/frontend/src/app/pages/dashboard.page.ts
+++ b/frontend/src/app/pages/dashboard.page.ts
@@ -1,17 +1,18 @@
 import { Component, OnInit, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
+import { ButtonModule } from 'primeng/button';
 import { ApiService } from '../core/services/api.service';
 
 @Component({
   selector: 'app-dashboard',
   standalone: true,
-  imports: [CommonModule, FormsModule],
+  imports: [CommonModule, FormsModule, ButtonModule],
   template: `
     <div class="p-4">
       <div class="flex justify-between mb-3">
         <h1 class="text-lg font-medium">Bots</h1>
-        <button class="btn primary" (click)="openAdd=true">Add Bot</button>
+        <p-button label="Add Bot" (onClick)="openAdd=true" severity="primary"></p-button>
       </div>
       <table class="tbl w-full">
         <tr>
@@ -28,16 +29,16 @@ import { ApiService } from '../core/services/api.service';
           <td>{{ b.exchange }}</td>
           <td>{{ b.symbol }}</td>
           <td>{{ b.risk_profile }}</td>
-          <td><button class="btn" (click)="stop(b.id)">Stop</button></td>
-        </tr>
+          <td><p-button label="Stop" (onClick)="stop(b.id)"></p-button></td>
+      </tr>
       </table>
     </div>
 
-    <div *ngIf="openAdd" class="fixed inset-0 bg-black/50 grid place-items-center">
-      <div class="bg-white rounded p-4 w-[400px] max-w-[95vw]">
+    <div *ngIf="openAdd" class="fixed inset-0 grid place-items-center">
+      <div class="rounded p-4 w-[400px] max-w-[95vw]">
         <div class="flex items-center justify-between mb-3">
           <div class="font-medium">Add Bot</div>
-          <button class="text-sm" (click)="openAdd=false">✕</button>
+          <p-button label="Close" (onClick)="openAdd=false" text></p-button>
         </div>
         <div class="grid gap-3">
           <div>
@@ -59,8 +60,8 @@ import { ApiService } from '../core/services/api.service';
             <input class="border rounded p-2 w-full" [(ngModel)]="risk" />
           </div>
           <div class="flex gap-2 mt-2">
-            <button class="btn primary" (click)="start()">Start</button>
-            <button class="btn" (click)="openAdd=false">Cancel</button>
+            <p-button label="Start" (onClick)="start()" severity="primary"></p-button>
+            <p-button label="Cancel" (onClick)="openAdd=false"></p-button>
           </div>
         </div>
       </div>

--- a/frontend/src/app/pages/logs.page.ts
+++ b/frontend/src/app/pages/logs.page.ts
@@ -1,6 +1,8 @@
 import { Component, ElementRef, ViewChild } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
+import { ButtonModule } from 'primeng/button';
+import { CardModule } from 'primeng/card';
 import { Subscription } from 'rxjs';
 import { WsService } from '../core/services/ws.service';
 import { ApiService } from '../core/services/api.service';
@@ -9,20 +11,20 @@ import { ActivatedRoute } from '@angular/router';
 @Component({
   selector: 'app-logs',
   standalone: true,
-  imports: [CommonModule, FormsModule],
+  imports: [CommonModule, FormsModule, ButtonModule, CardModule],
   template: `
     <h1>Logs</h1>
     <div class="status" style="margin-top:8px;display:flex;align-items:center;gap:8px;">
       <span>Connection: {{ status }}</span>
-      <button *ngIf="status !== 'connected'" type="button" (click)="retry()">Retry</button>
+      <p-button *ngIf="status !== 'connected'" type="button" (onClick)="retry()" label="Retry"></p-button>
     </div>
-    <div class="card" style="padding:12px;margin-top:8px;">
+    <p-card class="mt-2 p-3">
       <div style="display:flex;gap:8px;margin-bottom:8px;">
         <input [(ngModel)]="filter" placeholder="Filter"/>
-        <button type="button" (click)="clear()">Clear</button>
+        <p-button type="button" (onClick)="clear()" label="Clear"></p-button>
       </div>
       <pre #pane style="max-height:400px;overflow:auto;">{{ filtered.join('\n') }}</pre>
-    </div>
+    </p-card>
   `
 })
 export class LogsPage {

--- a/frontend/src/app/pages/risk.page.ts
+++ b/frontend/src/app/pages/risk.page.ts
@@ -13,19 +13,19 @@ import { ToastService } from '../shared/ui/toast.service';
   template: `
     <h1>Risk</h1>
 
-    <div class="card" style="padding:12px;margin-top:8px;">
+    <p-card class="mt-2">
       <div *ngIf="loadingStatus">Загрузка статуса...</div>
       <ng-container *ngIf="!loadingStatus">
         <div class="row">
           <div class="chip" [class.on]="status?.allowed">Entries: {{ status?.allowed ? 'ALLOWED' : 'BLOCKED' }}</div>
-          <button class="btn" (click)="refreshStatus()">Обновить</button>
-          <button class="btn warn" (click)="unlock()" *ngIf="!status?.allowed">Снять блокировки</button>
+          <p-button label="Обновить" (onClick)="refreshStatus()"></p-button>
+          <p-button label="Снять блокировки" (onClick)="unlock()" *ngIf="!status?.allowed" severity="warning"></p-button>
         </div>
         <div class="muted" *ngIf="status?.reason">Reason: {{ status?.reason }}</div>
       </ng-container>
-    </div>
+    </p-card>
 
-    <div class="card" style="padding:12px;margin-top:8px;">
+    <p-card class="mt-2">
       <div *ngIf="loadingPolicies">Загрузка политик...</div>
       <ng-container *ngIf="!loadingPolicies">
         <form [formGroup]="policiesForm">
@@ -36,13 +36,13 @@ import { ToastService } from '../shared/ui/toast.service';
           </label>
         </form>
         <div class="muted" *ngIf="!policies.length">Политики не найдены</div>
-        <div class="row" style="margin-top:8px;">
-          <button class="btn" type="button" (click)="refreshPolicies()">Обновить</button>
+        <div class="row mt-2">
+          <p-button label="Обновить" type="button" (onClick)="refreshPolicies()"></p-button>
         </div>
       </ng-container>
-    </div>
+    </p-card>
 
-    <div class="card" style="padding:12px;margin-top:8px;">
+    <p-card class="mt-2">
       <form [formGroup]="limitsForm" (ngSubmit)="save()">
         <div *ngIf="loadingLimits">Загрузка лимитов...</div>
         <div *ngIf="!loadingLimits">
@@ -72,10 +72,10 @@ import { ToastService } from '../shared/ui/toast.service';
               <input type="number" formControlName="max_loss_usd" />
             </label>
           </div>
-          <button class="btn primary" type="submit" [disabled]="loadingLimits">Сохранить</button>
+          <p-button label="Сохранить" type="submit" [disabled]="loadingLimits" severity="primary"></p-button>
         </div>
       </form>
-    </div>
+    </p-card>
   `
 })
 export class RiskPage {

--- a/frontend/src/app/pages/strategies.component.ts
+++ b/frontend/src/app/pages/strategies.component.ts
@@ -17,8 +17,8 @@ import { ApiService } from '../core/services/api.service';
     </select>
     <input [(ngModel)]="exchange" placeholder="exchange" class="border p-1 mr-2" />
     <input [(ngModel)]="symbol" placeholder="symbol" class="border p-1 mr-2" />
-    <button class="btn" (click)="start()">Start</button>
-    <button class="btn" (click)="stop()">Stop</button>
+    <p-button label="Start" (onClick)="start()"></p-button>
+    <p-button label="Stop" (onClick)="stop()"></p-button>
   </div>
   `
 })

--- a/frontend/src/app/pages/strategies.page.ts
+++ b/frontend/src/app/pages/strategies.page.ts
@@ -17,11 +17,11 @@ import { firstValueFrom } from 'rxjs';
       <app-strategies-modern (create)="onCreate()" (importCfg)="onImport()" (edit)="onEdit($event)" (remove)="onRemove($event)" #list></app-strategies-modern>
     </div>
 
-    <div *ngIf="openCreate" class="fixed inset-0 bg-black/50 grid place-items-center">
-      <div class="bg-white rounded p-4 w-[700px] max-w-[95vw]">
+    <div *ngIf="openCreate" class="fixed inset-0 grid place-items-center">
+      <div class="rounded p-4 w-[700px] max-w-[95vw]">
         <div class="flex items-center justify-between mb-3">
           <div class="font-medium">{{ editing ? 'Edit Strategy' : 'Create Strategy' }}</div>
-          <button class="text-sm" (click)="openCreate=false; editing=false">✕</button>
+          <p-button label="Close" (onClick)="openCreate=false; editing=false" text></p-button>
         </div>
         <div class="grid grid-cols-2 gap-3">
           <div>
@@ -40,18 +40,18 @@ import { firstValueFrom } from 'rxjs';
             <app-json-schema-form [schema]="schema" [(model)]="cfg"></app-json-schema-form>
           </div>
           <div class="col-span-2 mt-2 flex gap-2">
-            <button class="btn primary" (click)="submitSave()">Save</button>
-            <button class="btn" (click)="openCreate=false; editing=false">Cancel</button>
+            <p-button label="Save" (onClick)="submitSave()" severity="primary"></p-button>
+            <p-button label="Cancel" (onClick)="openCreate=false; editing=false"></p-button>
           </div>
         </div>
       </div>
     </div>
 
-    <div *ngIf="openImport" class="fixed inset-0 bg-black/50 grid place-items-center">
-      <div class="bg-white rounded p-4 w-[500px] max-w-[95vw]">
+    <div *ngIf="openImport" class="fixed inset-0 grid place-items-center">
+      <div class="rounded p-4 w-[500px] max-w-[95vw]">
         <div class="flex items-center justify-between mb-3">
           <div class="font-medium">Import Strategy Config</div>
-          <button class="text-sm" (click)="openImport=false">✕</button>
+          <p-button label="Close" (onClick)="openImport=false" text></p-button>
         </div>
         <div class="grid gap-3">
           <div>
@@ -64,8 +64,8 @@ import { firstValueFrom } from 'rxjs';
             <input type="file" accept="application/json" (change)="onFile($event)">
           </div>
           <div class="flex gap-2 mt-2">
-            <button class="btn primary" (click)="submitImport()">Save</button>
-            <button class="btn" (click)="openImport=false">Cancel</button>
+            <p-button label="Save" (onClick)="submitImport()" severity="primary"></p-button>
+            <p-button label="Cancel" (onClick)="openImport=false"></p-button>
           </div>
         </div>
       </div>

--- a/frontend/src/app/prime-ng.module.ts
+++ b/frontend/src/app/prime-ng.module.ts
@@ -5,6 +5,7 @@ import { TableModule } from 'primeng/table';
 import { DropdownModule } from 'primeng/dropdown';
 import { DialogModule } from 'primeng/dialog';
 import { ToastModule } from 'primeng/toast';
+import { BadgeModule } from 'primeng/badge';
 
 @NgModule({
   exports: [
@@ -13,7 +14,8 @@ import { ToastModule } from 'primeng/toast';
     TableModule,
     DropdownModule,
     DialogModule,
-    ToastModule
+    ToastModule,
+    BadgeModule
   ]
 })
 export class PrimeNgModule {}

--- a/frontend/src/app/shell/app-shell.component.ts
+++ b/frontend/src/app/shell/app-shell.component.ts
@@ -2,30 +2,31 @@ import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterLink, RouterOutlet } from '@angular/router';
 import { RouterLinkActive } from '@angular/router';
+import { ButtonModule } from 'primeng/button';
 
 @Component({
   standalone: true,
   selector: 'app-shell',
-  imports: [RouterOutlet, RouterLink, CommonModule, RouterLinkActive],
+  imports: [RouterOutlet, RouterLink, CommonModule, RouterLinkActive, ButtonModule],
   template: `
   <div class="min-h-screen grid grid-cols-[240px_1fr]">
-    <aside class="bg-[#0d1116] border-r border-[#1b2026] p-3">
+    <aside class="border-r p-3">
       <div class="flex items-center gap-2 mb-6 px-1">
-        <button class="btn" (click)="collapsed = !collapsed">☰</button>
-        <div class="text-sm text-[#9aa4ad]" *ngIf="!collapsed">Amadeus</div>
+        <p-button label="☰" (onClick)="collapsed = !collapsed"></p-button>
+        <div class="text-sm" *ngIf="!collapsed">Amadeus</div>
       </div>
       <nav class="flex flex-col gap-1">
-        <a routerLink="/dashboard" routerLinkActive="bg-[#151a20]" class="flex items-center gap-3 px-3 py-2 rounded-xl hover:bg-[#141820]">🏠 <span *ngIf="!collapsed">Dashboard</span></a>
-        <a routerLink="/market" routerLinkActive="bg-[#151a20]" class="flex items-center gap-3 px-3 py-2 rounded-xl hover:bg-[#141820]">📈 <span *ngIf="!collapsed">Market</span></a>
-        <a routerLink="/strategies" routerLinkActive="bg-[#151a20]" class="flex items-center gap-3 px-3 py-2 rounded-xl hover:bg-[#141820]">🤖 <span *ngIf="!collapsed">Strategies</span></a>
+        <a routerLink="/dashboard" class="flex items-center gap-3 px-3 py-2 rounded-xl">🏠 <span *ngIf="!collapsed">Dashboard</span></a>
+        <a routerLink="/market" class="flex items-center gap-3 px-3 py-2 rounded-xl">📈 <span *ngIf="!collapsed">Market</span></a>
+        <a routerLink="/strategies" class="flex items-center gap-3 px-3 py-2 rounded-xl">🤖 <span *ngIf="!collapsed">Strategies</span></a>
       </nav>
     </aside>
 
     <main>
-      <header class="flex items-center justify-between px-4 h-14 border-b border-[#1b2026] bg-[#0d1116]">
-        <div class="text-sm text-[#9aa4ad]">v17 UI</div>
+      <header class="flex items-center justify-between px-4 h-14 border-b">
+        <div class="text-sm">v17 UI</div>
         <div class="flex items-center gap-2">
-          <button class="btn" (click)="toggleTheme()" title="Toggle theme">Dark</button>
+          <p-button label="Dark" (onClick)="toggleTheme()" title="Toggle theme"></p-button>
         </div>
       </header>
       <section class="p-4">

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -41,12 +41,6 @@ a, .link {
   color: var(--accent);
 }
 
-.card {
-  background: var(--surface);
-  border-radius: var(--card-radius);
-  box-shadow: var(--shadow);
-}
-
 .flash-up {
   animation: flashUp 0.35s;
 }
@@ -79,44 +73,6 @@ a, .link {
 .topbar {
   background: var(--bg-1);
   border-bottom: 1px solid var(--gridline);
-}
-
-.btn {
-  padding: 0.5rem 1rem;
-  border: 1px solid var(--gridline);
-  background: transparent;
-  color: var(--text-0);
-  cursor: pointer;
-  transition: background 0.2s;
-}
-
-.btn:hover {
-  background: var(--surface);
-}
-
-.btn.primary {
-  background: var(--accent);
-  border-color: var(--accent);
-  color: #fff;
-}
-
-.badge {
-  display: inline-block;
-  padding: 0.125rem 0.5rem;
-  border-radius: 9999px;
-  background: var(--gridline);
-  color: var(--text-0);
-  font-size: 0.75rem;
-}
-
-.badge.ok {
-  background: var(--ok);
-  color: #fff;
-}
-
-.badge.err {
-  background: var(--error);
-  color: #fff;
 }
 
 /*# sourceMappingURL=styles.css.map */


### PR DESCRIPTION
## Summary
- replace legacy `.btn`, `.badge`, and `.card` styles with PrimeNG elements
- rely on PrimeNG Aura theme and PrimeFlex for layout
- expand PrimeNG module exports for badge support

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Could not resolve "@primeuix/themes/aura" and other module errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bbb3d24fd0832d96bfe06dfed5e77e