### PR TITLE
feat: replace UI elements with PrimeNG components

### DIFF
--- a/frontend/src/app/features/risk/risk.component.ts
+++ b/frontend/src/app/features/risk/risk.component.ts
@@ -3,28 +3,28 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { ApiService } from '../../core/services/api.service';
 import { firstValueFrom } from 'rxjs';
+import { PrimeNgModule } from '../../prime-ng.module';
+import { ToastService } from '../../shared/ui/toast.service';
 
 @Component({
   standalone: true,
   selector: 'app-risk',
-  imports: [CommonModule, FormsModule],
+  imports: [CommonModule, FormsModule, PrimeNgModule],
   template: `
   <div class="p-4">
     <h2 class="text-xl font-semibold mb-4">Risk Policies</h2>
     <div class="grid md:grid-cols-2 gap-4">
       <div class="border rounded p-4">
         <div class="grid grid-cols-2 gap-2">
-          <select class="border rounded p-2" [(ngModel)]="sid">
-            <option *ngFor="let s of strategies" [value]="s.id">{{ s.id }}</option>
-          </select>
-          <button class="px-3 py-2 rounded bg-black text-white" (click)="load()">Load</button>
+          <p-dropdown [options]="strategies" optionLabel="id" optionValue="id" [(ngModel)]="sid"></p-dropdown>
+          <p-button label="Load" (onClick)="load()" severity="secondary"></p-button>
           <label>max_active_orders</label><input type="number" class="border rounded p-2" [(ngModel)]="pol.max_active_orders">
           <label>max_dd</label><input type="number" step="0.01" class="border rounded p-2" [(ngModel)]="pol.max_dd">
           <label>max_leverage</label><input type="number" class="border rounded p-2" [(ngModel)]="pol.max_leverage">
           <label>max_notional_per_symbol.BTCUSDT</label><input type="number" class="border rounded p-2" [(ngModel)]="pol.max_notional_per_symbol.BTCUSDT">
           <label>max_pos_qty_per_symbol.BTCUSDT</label><input type="number" step="0.0001" class="border rounded p-2" [(ngModel)]="pol.max_pos_qty_per_symbol.BTCUSDT">
           <div class="col-span-2">
-            <button class="px-3 py-2 rounded bg-black text-white" (click)="save()">Save</button>
+            <p-button label="Save" (onClick)="save()" severity="primary"></p-button>
           </div>
         </div>
       </div>
@@ -34,7 +34,7 @@ import { firstValueFrom } from 'rxjs';
           <div *ngFor="let it of log()">{{ it.ts }} — [{{ it.strategy_id }}] {{ it.action }} — {{ it.msg }}</div>
         </div>
         <div class="mt-2">
-          <button class="px-3 py-2 rounded" (click)="refreshLog()">Refresh</button>
+          <p-button label="Refresh" (onClick)="refreshLog()"></p-button>
         </div>
       </div>
     </div>
@@ -43,6 +43,7 @@ import { firstValueFrom } from 'rxjs';
 })
 export class RiskComponent {
   api = inject(ApiService);
+  private toast = inject(ToastService);
   sid='';
   strategies: {id: string; running: boolean}[] = [];
   pol:any={max_active_orders:100, max_dd:0.3, max_leverage:5.0, max_notional_per_symbol:{}, max_pos_qty_per_symbol:{}};
@@ -67,7 +68,12 @@ export class RiskComponent {
     this.pol = Object.assign({max_active_orders:100, max_dd:0.3, max_leverage:5.0, max_notional_per_symbol:{}, max_pos_qty_per_symbol:{}}, p||{});
   }
   async save() {
-    await firstValueFrom(this.api.post(`/riskx/policies/${this.sid}`, this.pol));
+    try {
+      await firstValueFrom(this.api.post(`/riskx/policies/${this.sid}`, this.pol));
+      this.toast.push('Policy saved', 'success');
+    } catch (err: any) {
+      this.toast.push(`Save failed: ${err?.error?.error || err?.message || 'unknown'}`, 'error');
+    }
   }
   async refreshLog() {
     const j: any = await firstValueFrom(this.api.get('/riskx/log'));

--- a/frontend/src/app/pages/dashboard.page.ts
+++ b/frontend/src/app/pages/dashboard.page.ts
@@ -1,71 +1,66 @@
 import { Component, OnInit, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { ButtonModule } from 'primeng/button';
 import { ApiService } from '../core/services/api.service';
+import { PrimeNgModule } from '../prime-ng.module';
 
 @Component({
   selector: 'app-dashboard',
   standalone: true,
-  imports: [CommonModule, FormsModule, ButtonModule],
+  imports: [CommonModule, FormsModule, PrimeNgModule],
   template: `
     <div class="p-4">
       <div class="flex justify-between mb-3">
         <h1 class="text-lg font-medium">Bots</h1>
         <p-button label="Add Bot" (onClick)="openAdd=true" severity="primary"></p-button>
       </div>
-      <table class="tbl w-full">
-        <tr>
-          <th>ID</th>
-          <th>Strategy</th>
-          <th>Exchange</th>
-          <th>Symbol</th>
-          <th>Risk</th>
-          <th></th>
-        </tr>
-        <tr *ngFor="let b of bots">
-          <td>{{ b.id }}</td>
-          <td>{{ b.strategy_id }}</td>
-          <td>{{ b.exchange }}</td>
-          <td>{{ b.symbol }}</td>
-          <td>{{ b.risk_profile }}</td>
-          <td><p-button label="Stop" (onClick)="stop(b.id)"></p-button></td>
-      </tr>
-      </table>
+      <p-table [value]="bots" class="w-full">
+        <ng-template pTemplate="header">
+          <tr>
+            <th>ID</th>
+            <th>Strategy</th>
+            <th>Exchange</th>
+            <th>Symbol</th>
+            <th>Risk</th>
+            <th></th>
+          </tr>
+        </ng-template>
+        <ng-template pTemplate="body" let-b>
+          <tr>
+            <td>{{ b.id }}</td>
+            <td>{{ b.strategy_id }}</td>
+            <td>{{ b.exchange }}</td>
+            <td>{{ b.symbol }}</td>
+            <td>{{ b.risk_profile }}</td>
+            <td><p-button label="Stop" (onClick)="stop(b.id)"></p-button></td>
+          </tr>
+        </ng-template>
+      </p-table>
     </div>
-
-    <div *ngIf="openAdd" class="fixed inset-0 grid place-items-center">
-      <div class="rounded p-4 w-[400px] max-w-[95vw]">
-        <div class="flex items-center justify-between mb-3">
-          <div class="font-medium">Add Bot</div>
-          <p-button label="Close" (onClick)="openAdd=false" text></p-button>
+    <p-dialog [(visible)]="openAdd" [modal]="true" header="Add Bot" styleClass="w-[400px] max-w-[95vw]">
+      <div class="grid gap-3">
+        <div>
+          <label class="block text-sm mb-1">Strategy</label>
+          <p-dropdown [options]="strategyOptions" [(ngModel)]="strategy_id"></p-dropdown>
         </div>
-        <div class="grid gap-3">
-          <div>
-            <label class="block text-sm mb-1">Strategy</label>
-            <select class="border rounded p-2 w-full" [(ngModel)]="strategy_id">
-              <option *ngFor="let s of strategies" [value]="s.id">{{ s.id }}</option>
-            </select>
-          </div>
-          <div>
-            <label class="block text-sm mb-1">Exchange</label>
-            <input class="border rounded p-2 w-full" [(ngModel)]="exchange" />
-          </div>
-          <div>
-            <label class="block text-sm mb-1">Symbol</label>
-            <input class="border rounded p-2 w-full" [(ngModel)]="symbol" />
-          </div>
-          <div>
-            <label class="block text-sm mb-1">Risk Profile</label>
-            <input class="border rounded p-2 w-full" [(ngModel)]="risk" />
-          </div>
-          <div class="flex gap-2 mt-2">
-            <p-button label="Start" (onClick)="start()" severity="primary"></p-button>
-            <p-button label="Cancel" (onClick)="openAdd=false"></p-button>
-          </div>
+        <div>
+          <label class="block text-sm mb-1">Exchange</label>
+          <input class="border rounded p-2 w-full" [(ngModel)]="exchange" />
+        </div>
+        <div>
+          <label class="block text-sm mb-1">Symbol</label>
+          <input class="border rounded p-2 w-full" [(ngModel)]="symbol" />
+        </div>
+        <div>
+          <label class="block text-sm mb-1">Risk Profile</label>
+          <input class="border rounded p-2 w-full" [(ngModel)]="risk" />
+        </div>
+        <div class="flex gap-2 mt-2">
+          <p-button label="Start" (onClick)="start()" severity="primary"></p-button>
+          <p-button label="Cancel" (onClick)="openAdd=false"></p-button>
         </div>
       </div>
-    </div>
+    </p-dialog>
   `,
 })
 export class DashboardPage implements OnInit {
@@ -115,5 +110,9 @@ export class DashboardPage implements OnInit {
   async stop(id: string) {
     await this.api.stopBot(id);
     await this.refresh();
+  }
+
+  get strategyOptions() {
+    return this.strategies.map(s => ({ label: s.id, value: s.id }));
   }
 }

--- a/frontend/src/app/pages/strategies.page.ts
+++ b/frontend/src/app/pages/strategies.page.ts
@@ -16,60 +16,41 @@ import { firstValueFrom } from 'rxjs';
     <div class="p-4">
       <app-strategies-modern (create)="onCreate()" (importCfg)="onImport()" (edit)="onEdit($event)" (remove)="onRemove($event)" #list></app-strategies-modern>
     </div>
-
-    <div *ngIf="openCreate" class="fixed inset-0 grid place-items-center">
-      <div class="rounded p-4 w-[700px] max-w-[95vw]">
-        <div class="flex items-center justify-between mb-3">
-          <div class="font-medium">{{ editing ? 'Edit Strategy' : 'Create Strategy' }}</div>
-          <p-button label="Close" (onClick)="openCreate=false; editing=false" text></p-button>
+    <p-dialog [(visible)]="openCreate" [modal]="true" [header]="editing ? 'Edit Strategy' : 'Create Strategy'" styleClass="w-[700px] max-w-[95vw]">
+      <div class="grid grid-cols-2 gap-3">
+        <div>
+          <label class="block text-sm mb-1">Strategy</label>
+          <p-dropdown [options]="strategyOptions" [(ngModel)]="sid" (onChange)="loadSchema()"></p-dropdown>
         </div>
-        <div class="grid grid-cols-2 gap-3">
-          <div>
-            <label class="block text-sm mb-1">Strategy</label>
-            <select class="border rounded p-2 w-full" [(ngModel)]="sid" (ngModelChange)="loadSchema()">
-              <option *ngFor="let s of strategies" [value]="s.id">{{ s.id }}</option>
-            </select>
-          </div>
-          <div>
-            <label class="block text-sm mb-1">Risk Policy</label>
-            <select class="border rounded p-2 w-full" [(ngModel)]="riskPolicy" [disabled]="!riskPolicies.length">
-              <option *ngFor="let r of riskPolicies" [value]="r">{{ r }}</option>
-            </select>
-          </div>
-          <div class="col-span-2">
-            <app-json-schema-form [schema]="schema" [(model)]="cfg"></app-json-schema-form>
-          </div>
-          <div class="col-span-2 mt-2 flex gap-2">
-            <p-button label="Save" (onClick)="submitSave()" severity="primary"></p-button>
-            <p-button label="Cancel" (onClick)="openCreate=false; editing=false"></p-button>
-          </div>
+        <div>
+          <label class="block text-sm mb-1">Risk Policy</label>
+          <p-dropdown [options]="riskPolicyOptions" [(ngModel)]="riskPolicy" [disabled]="!riskPolicyOptions.length"></p-dropdown>
+        </div>
+        <div class="col-span-2">
+          <app-json-schema-form [schema]="schema" [(model)]="cfg"></app-json-schema-form>
+        </div>
+        <div class="col-span-2 mt-2 flex gap-2">
+          <p-button label="Save" (onClick)="submitSave()" severity="primary"></p-button>
+          <p-button label="Cancel" (onClick)="openCreate=false; editing=false"></p-button>
         </div>
       </div>
-    </div>
+    </p-dialog>
 
-    <div *ngIf="openImport" class="fixed inset-0 grid place-items-center">
-      <div class="rounded p-4 w-[500px] max-w-[95vw]">
-        <div class="flex items-center justify-between mb-3">
-          <div class="font-medium">Import Strategy Config</div>
-          <p-button label="Close" (onClick)="openImport=false" text></p-button>
+    <p-dialog [(visible)]="openImport" [modal]="true" header="Import Strategy Config" styleClass="w-[500px] max-w-[95vw]">
+      <div class="grid gap-3">
+        <div>
+          <label class="block text-sm mb-1">Strategy</label>
+          <p-dropdown [options]="strategyOptions" [(ngModel)]="sid"></p-dropdown>
         </div>
-        <div class="grid gap-3">
-          <div>
-            <label class="block text-sm mb-1">Strategy</label>
-            <select class="border rounded p-2 w-full" [(ngModel)]="sid">
-              <option *ngFor="let s of strategies" [value]="s.id">{{ s.id }}</option>
-            </select>
-          </div>
-          <div>
-            <input type="file" accept="application/json" (change)="onFile($event)">
-          </div>
-          <div class="flex gap-2 mt-2">
-            <p-button label="Save" (onClick)="submitImport()" severity="primary"></p-button>
-            <p-button label="Cancel" (onClick)="openImport=false"></p-button>
-          </div>
+        <div>
+          <input type="file" accept="application/json" (change)="onFile($event)">
+        </div>
+        <div class="flex gap-2 mt-2">
+          <p-button label="Save" (onClick)="submitImport()" severity="primary"></p-button>
+          <p-button label="Cancel" (onClick)="openImport=false"></p-button>
         </div>
       </div>
-    </div>
+    </p-dialog>
   `
 })
 export class StrategiesPage {
@@ -205,5 +186,13 @@ export class StrategiesPage {
     if (!this.riskPolicy && this.riskPolicies.length) {
       this.riskPolicy = this.riskPolicies[0];
     }
+  }
+
+  get strategyOptions() {
+    return this.strategies.map(s => ({ label: s.id, value: s.id }));
+  }
+
+  get riskPolicyOptions() {
+    return this.riskPolicies.map(r => ({ label: r, value: r }));
   }
 }

--- a/frontend/src/app/shared/ui/toast.service.ts
+++ b/frontend/src/app/shared/ui/toast.service.ts
@@ -1,16 +1,13 @@
-import { Injectable, signal } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
+import { MessageService } from 'primeng/api';
 
-export interface Toast { id: number; text: string; kind?: 'info'|'success'|'error'; }
+export type ToastKind = 'info' | 'success' | 'error';
 
 @Injectable({ providedIn: 'root' })
 export class ToastService {
-  list = signal<Toast[]>([]);
-  push(text: string, kind: Toast['kind']='info') {
-    const id = Date.now() + Math.random();
-    this.list.update(arr => arr.concat({ id, text, kind }));
-    setTimeout(() => this.dismiss(id), 3000);
-  }
-  dismiss(id: number) {
-    this.list.update(arr => arr.filter(t => t.id !== id));
+  private msg = inject(MessageService);
+
+  push(text: string, kind: ToastKind = 'info') {
+    this.msg.add({ severity: kind, summary: text });
   }
 }


### PR DESCRIPTION
## Summary
- refactor risk management view to use PrimeNG dropdowns, buttons, and toast feedback
- migrate strategy management modals to PrimeNG dialogs and dropdown selectors
- convert bot dashboard to PrimeNG table and dialog for bot creation
- replace custom toast service with PrimeNG MessageService

## Testing
- `npm run build` *(fails: Cannot find module '@primeuix/themes/aura')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'pydantic_settings')*


------
https://chatgpt.com/codex/tasks/task_e_68bbb576df10832dabc0f66c620a5fc5