### PR TITLE
refactor: use PrimeNG components for strategy forms

### DIFF
--- a/frontend/src/app/prime-ng.module.ts
+++ b/frontend/src/app/prime-ng.module.ts
@@ -6,6 +6,12 @@ import { DropdownModule } from 'primeng/dropdown';
 import { DialogModule } from 'primeng/dialog';
 import { ToastModule } from 'primeng/toast';
 import { BadgeModule } from 'primeng/badge';
+import { InputTextModule } from 'primeng/inputtext';
+import { FileUploadModule } from 'primeng/fileupload';
+import { MessagesModule } from 'primeng/messages';
+import { MessageModule } from 'primeng/message';
+import { InputNumberModule } from 'primeng/inputnumber';
+import { InputSwitchModule } from 'primeng/inputswitch';
 
 @NgModule({
   exports: [
@@ -15,7 +21,13 @@ import { BadgeModule } from 'primeng/badge';
     DropdownModule,
     DialogModule,
     ToastModule,
-    BadgeModule
+    BadgeModule,
+    InputTextModule,
+    FileUploadModule,
+    MessagesModule,
+    MessageModule,
+    InputNumberModule,
+    InputSwitchModule
   ]
 })
 export class PrimeNgModule {}

--- a/frontend/src/app/shared/json-schema-form.component.ts
+++ b/frontend/src/app/shared/json-schema-form.component.ts
@@ -1,26 +1,25 @@
 import { Component, Input, Output, EventEmitter } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
+import { PrimeNgModule } from '../prime-ng.module';
 
 type Schema = any;
 
 @Component({
   standalone: true,
   selector: 'app-json-schema-form',
-  imports: [CommonModule, FormsModule],
+  imports: [CommonModule, FormsModule, PrimeNgModule],
   template: `
   <div class="grid gap-3" *ngIf="schema">
     <ng-container *ngFor="let key of keys()">
       <label class="block text-sm mb-1">{{ key }}</label>
       <ng-container [ngSwitch]="typeOf(key)">
-        <input *ngSwitchCase="'string'" class="border rounded p-2 w-full" [(ngModel)]="model[key]" (ngModelChange)="emit()" />
-        <input *ngSwitchCase="'number'" type="number" class="border rounded p-2 w-full" [(ngModel)]="model[key]" (ngModelChange)="emit()" />
-        <input *ngSwitchCase="'integer'" type="number" class="border rounded p-2 w-full" [(ngModel)]="model[key]" (ngModelChange)="emit()" />
-        <input *ngSwitchCase="'boolean'" type="checkbox" class="mr-2" [(ngModel)]="model[key]" (ngModelChange)="emit()" />
-        <select *ngSwitchCase="'enum'" class="border rounded p-2 w-full" [(ngModel)]="model[key]" (ngModelChange)="emit()">
-          <option *ngFor="let v of schema.properties[key].enum" [value]="v">{{ v }}</option>
-        </select>
-        <input *ngSwitchDefault class="border rounded p-2 w-full" [(ngModel)]="model[key]" (ngModelChange)="emit()" />
+        <p-inputText *ngSwitchCase="'string'" class="w-full" [(ngModel)]="model[key]" (ngModelChange)="emit()"></p-inputText>
+        <p-inputNumber *ngSwitchCase="'number'" class="w-full" [(ngModel)]="model[key]" (ngModelChange)="emit()"></p-inputNumber>
+        <p-inputNumber *ngSwitchCase="'integer'" class="w-full" [(ngModel)]="model[key]" (ngModelChange)="emit()"></p-inputNumber>
+        <p-inputSwitch *ngSwitchCase="'boolean'" [(ngModel)]="model[key]" (ngModelChange)="emit()"></p-inputSwitch>
+        <p-dropdown *ngSwitchCase="'enum'" class="w-full" [options]="schema.properties[key].enum.map(v => ({label:v, value:v}))" [(ngModel)]="model[key]" (ngModelChange)="emit()"></p-dropdown>
+        <p-inputText *ngSwitchDefault class="w-full" [(ngModel)]="model[key]" (ngModelChange)="emit()"></p-inputText>
       </ng-container>
       <div class="text-xs text-gray-500" *ngIf="schema.properties[key]?.description">{{ schema.properties[key].description }}</div>
     </ng-container>

--- a/frontend/src/app/shared/ui/json-schema-form.component.ts
+++ b/frontend/src/app/shared/ui/json-schema-form.component.ts
@@ -1,26 +1,29 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
+import { PrimeNgModule } from '../../prime-ng.module';
 
 type Schema = any;
 
 @Component({
   standalone: true,
   selector: 'app-json-schema-form',
-  imports: [CommonModule, FormsModule],
+  imports: [CommonModule, FormsModule, PrimeNgModule],
   template: `
   <div class="grid gap-3">
     @for (key of keys(); track key) {
       <div>
         <label class="block text-sm mb-1">{{ key }}</label>
         @if (schema.properties[key].type === 'string') {
-          <input class="border rounded p-2 w-full" [(ngModel)]="model[key]">
+          <p-inputText class="w-full" [(ngModel)]="model[key]"></p-inputText>
         } @else if (schema.properties[key].type === 'number' || schema.properties[key].type === 'integer') {
-          <input type="number" class="border rounded p-2 w-full" [(ngModel)]="model[key]">
+          <p-inputNumber class="w-full" [(ngModel)]="model[key]"></p-inputNumber>
         } @else if (schema.properties[key].type === 'boolean') {
-          <input type="checkbox" [(ngModel)]="model[key]">
+          <p-inputSwitch [(ngModel)]="model[key]"></p-inputSwitch>
+        } @else if (schema.properties[key].enum) {
+          <p-dropdown class="w-full" [options]="schema.properties[key].enum.map(v => ({label: v, value: v}))" [(ngModel)]="model[key]"></p-dropdown>
         } @else {
-          <input class="border rounded p-2 w-full" [(ngModel)]="model[key]">
+          <p-inputText class="w-full" [(ngModel)]="model[key]"></p-inputText>
         }
       </div>
     }


### PR DESCRIPTION
## Summary
- extract strategy create/import dialogs into PrimeNG dialogs with validation
- swap native inputs for PrimeNG controls and add file upload handling
- extend PrimeNG module with form and message components

## Testing
- `npm test`
- `npm run build` *(fails: Cannot find module '@primeuix/themes/aura' and unresolved PrimeNG exports)*

------
https://chatgpt.com/codex/tasks/task_e_68bbb6d46b68832da8fd6de625749dd3