### PR TITLE
feat: use PrimeNG toast for strategy notifications

### DIFF
--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -18,4 +18,6 @@
   <footer class="border-t border-tvborder py-3 text-center text-xs text-tvmuted">
     Built with PrimeNG + Tailwind
   </footer>
+
+  <p-toast></p-toast>
 </div>

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -1,10 +1,11 @@
 import { Component } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
+import { PrimeNgModule } from './prime-ng.module';
 
 @Component({
   selector: 'app-root',
   standalone: true,
-  imports: [RouterOutlet],
+  imports: [RouterOutlet, PrimeNgModule],
   templateUrl: './app.component.html',
   styleUrl: './app.component.css'
 })

--- a/frontend/src/app/features/strategies/strategies-modern.component.ts
+++ b/frontend/src/app/features/strategies/strategies-modern.component.ts
@@ -2,8 +2,8 @@ import { Component, EventEmitter, OnInit, Output, inject, signal } from '@angula
 import { CommonModule } from '@angular/common';
 import { Router, RouterModule } from '@angular/router';
 import { PrimeNgModule } from '../../prime-ng.module';
-import { ToastService } from '../../shared/ui/toast.service';
 import { ApiService } from '../../core/services/api.service';
+import { MessageService } from 'primeng/api';
 
 @Component({
   standalone: true,
@@ -60,7 +60,7 @@ import { ApiService } from '../../core/services/api.service';
 })
 export class StrategiesModernComponent implements OnInit {
   private api = inject(ApiService);
-  private toast = inject(ToastService);
+  private messageService = inject(MessageService);
   private router = inject(Router);
 
   @Output() create = new EventEmitter<void>();
@@ -110,7 +110,10 @@ export class StrategiesModernComponent implements OnInit {
       );
       this.items.set(list);
     } catch (err: any) {
-      this.toast.push(`Failed to load strategies: ${err?.error?.error || err?.message || 'unknown'}`, 'error');
+      this.messageService.add({
+        severity: 'error',
+        summary: `Failed to load strategies: ${err?.error?.error || err?.message || 'unknown'}`
+      });
     }
   }
 

--- a/frontend/src/app/features/strategies/strategies.component.ts
+++ b/frontend/src/app/features/strategies/strategies.component.ts
@@ -5,6 +5,7 @@ import { RouterLink } from '@angular/router';
 import { JsonSchemaFormComponent } from '../../shared/json-schema-form.component';
 import { ApiService } from '../../core/services/api.service';
 import { firstValueFrom } from 'rxjs';
+import { MessageService } from 'primeng/api';
 
 @Component({
   standalone: true,
@@ -74,6 +75,7 @@ export class StrategiesComponent {
   cfg: any = {};
   schema = signal<any>({type:'object', properties:{}});
   api = inject(ApiService);
+  msg = inject(MessageService);
   exchange = 'mock';
   symbol = '';
 
@@ -134,7 +136,10 @@ export class StrategiesComponent {
       await this.refresh();
     } catch (err:any) {
       console.error('Failed to start strategy', err);
-      alert(err?.error?.error || err?.message || 'Failed to start strategy');
+      this.msg.add({
+        severity: 'error',
+        summary: err?.error?.error || err?.message || 'Failed to start strategy'
+      });
     }
   }
 }

--- a/frontend/src/app/pages/strategies.component.ts
+++ b/frontend/src/app/pages/strategies.component.ts
@@ -2,8 +2,8 @@ import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { PrimeNgModule } from '../prime-ng.module';
-import { ToastService } from '../shared/ui/toast.service';
 import { ApiService } from '../core/services/api.service';
+import { MessageService } from 'primeng/api';
 
 @Component({
   standalone: true,
@@ -28,7 +28,7 @@ export class StrategiesComponent implements OnInit {
   exchange = 'mock';
   symbol = '';
 
-  constructor(private api: ApiService, private toast: ToastService) {}
+  constructor(private api: ApiService, private messageService: MessageService) {}
 
   async ngOnInit() {
     await this.loadStrategies();
@@ -41,7 +41,7 @@ export class StrategiesComponent implements OnInit {
         this.sid = this.strategies[0].id;
       }
     } catch (err: any) {
-      this.toast.push(`Failed to load strategies: ${err?.error?.error || err?.message || 'unknown'}`, 'error');
+      this.messageService.add({ severity: 'error', summary: `Failed to load strategies: ${err?.error?.error || err?.message || 'unknown'}` });
     }
   }
 
@@ -54,7 +54,7 @@ export class StrategiesComponent implements OnInit {
       });
       await this.loadStrategies();
     } catch (err: any) {
-      this.toast.push(`Start failed: ${err?.error?.error || err?.message || 'unknown'}`, 'error');
+      this.messageService.add({ severity: 'error', summary: `Start failed: ${err?.error?.error || err?.message || 'unknown'}` });
     }
   }
 
@@ -71,10 +71,10 @@ export class StrategiesComponent implements OnInit {
         await this.api.stopBot(bot.id);
         await this.loadStrategies();
       } else {
-        this.toast.push('Bot not found', 'error');
+        this.messageService.add({ severity: 'error', summary: 'Bot not found' });
       }
     } catch (err: any) {
-      this.toast.push(`Stop failed: ${err?.error?.error || err?.message || 'unknown'}`, 'error');
+      this.messageService.add({ severity: 'error', summary: `Stop failed: ${err?.error?.error || err?.message || 'unknown'}` });
     }
   }
 }

--- a/frontend/src/app/pages/strategies.page.ts
+++ b/frontend/src/app/pages/strategies.page.ts
@@ -5,7 +5,7 @@ import { StrategiesModernComponent } from '../features/strategies/strategies-mod
 import { JsonSchemaFormComponent } from '../shared/ui/json-schema-form.component';
 import { ApiService } from '../core/services/api.service';
 import { PrimeNgModule } from '../prime-ng.module';
-import { ToastService } from '../shared/ui/toast.service';
+import { MessageService } from 'primeng/api';
 import { firstValueFrom } from 'rxjs';
 
 @Component({
@@ -59,7 +59,7 @@ import { firstValueFrom } from 'rxjs';
 })
 export class StrategiesPage {
   private api = inject(ApiService);
-  private toast = inject(ToastService);
+  private messageService = inject(MessageService);
   @ViewChild('list') private list?: StrategiesModernComponent;
 
   openCreate = false;
@@ -105,7 +105,10 @@ export class StrategiesPage {
       this.cfg = res.config || {};
       this.riskPolicy = res.risk_policy || this.riskPolicy;
     } catch (err: any) {
-      this.toast.push(`Load failed: ${err?.error?.error || err?.message || 'unknown'}`, 'error');
+      this.messageService.add({
+        severity: 'error',
+        summary: `Load failed: ${err?.error?.error || err?.message || 'unknown'}`
+      });
     }
   }
 
@@ -114,7 +117,10 @@ export class StrategiesPage {
       await firstValueFrom(this.api.delete(`/strategies/${id}`));
       await this.list?.refresh();
     } catch (err: any) {
-      this.toast.push(`Delete failed: ${err?.error?.error || err?.message || 'unknown'}`, 'error');
+      this.messageService.add({
+        severity: 'error',
+        summary: `Delete failed: ${err?.error?.error || err?.message || 'unknown'}`
+      });
     }
   }
 
@@ -151,7 +157,10 @@ export class StrategiesPage {
       this.editing = false;
       await this.list?.refresh();
     } catch (err: any) {
-      this.toast.push(`Save failed: ${err?.error?.error || err?.message || 'unknown'}`, 'error');
+      this.messageService.add({
+        severity: 'error',
+        summary: `Save failed: ${err?.error?.error || err?.message || 'unknown'}`
+      });
     }
   }
 
@@ -191,7 +200,10 @@ export class StrategiesPage {
       this.importedCfg = {};
       await this.list?.refresh();
     } catch (err: any) {
-      this.toast.push(`Save failed: ${err?.error?.error || err?.message || 'unknown'}`, 'error');
+      this.messageService.add({
+        severity: 'error',
+        summary: `Save failed: ${err?.error?.error || err?.message || 'unknown'}`
+      });
     }
   }
 
@@ -199,15 +211,18 @@ export class StrategiesPage {
     try {
       this.riskPolicies = await this.api.getRiskPolicies();
       if (!this.riskPolicies.length) {
-        this.toast.push('No risk policies found', 'info');
+        this.messageService.add({ severity: 'info', summary: 'No risk policies found' });
       }
     } catch (err: any) {
       if (err?.status === 404) {
         this.riskPolicies = [];
-        this.toast.push('No risk policies found', 'info');
+        this.messageService.add({ severity: 'info', summary: 'No risk policies found' });
       } else {
         this.riskPolicies = [];
-        this.toast.push(`Load failed: ${err?.error?.error || err?.message || 'unknown'}`, 'error');
+        this.messageService.add({
+          severity: 'error',
+          summary: `Load failed: ${err?.error?.error || err?.message || 'unknown'}`
+        });
       }
     }
     if (!this.riskPolicy && this.riskPolicies.length) {


### PR DESCRIPTION
## Summary
- add global `<p-toast>` component and PrimeNg module import
- replace custom ToastService usage on strategy pages with PrimeNG `MessageService`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Could not resolve primeng modules)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bbb8ba161c832d800aa32250ae8953