### PR TITLE
refactor: adopt PrimeNG widgets

### DIFF
--- a/frontend/src/app/components/history/history.component.html
+++ b/frontend/src/app/components/history/history.component.html
@@ -23,56 +23,64 @@
     <div>
         <h4>Orders (последние)</h4>
         <div *ngIf="loadingO">Загрузка...</div>
-        <table *ngIf="!loadingO" class="tbl">
-            <tr>
-                <th style="width:60px;">ID</th>
-                <th style="width:140px;">TS</th>
-                <th style="width:80px;">Event</th>
-                <th style="width:100px;">Symbol</th>
-                <th style="width:60px;">Side</th>
-                <th style="width:80px;">Type</th>
-                <th style="width:80px;">Price</th>
-                <th style="width:80px;">Qty</th>
-                <th style="width:80px;">Status</th>
-            </tr>
-            <tr *ngFor="let o of orders">
-                <td class="mono">{{o.id}}</td>
-                <td class="mono">{{o.ts*1000 | date:'medium'}}</td>
-                <td>{{o.event}}</td>
-                <td>{{o.symbol}}</td>
-                <td>{{o.side}}</td>
-                <td>{{o.type}}</td>
-                <td class="mono">{{o.price}}</td>
-                <td class="mono">{{o.qty}}</td>
-                <td>{{o.status}}</td>
-            </tr>
-        </table>
+        <p-table *ngIf="!loadingO" [value]="orders" styleClass="tbl">
+            <ng-template pTemplate="header">
+                <tr>
+                    <th style="width:60px;">ID</th>
+                    <th style="width:140px;">TS</th>
+                    <th style="width:80px;">Event</th>
+                    <th style="width:100px;">Symbol</th>
+                    <th style="width:60px;">Side</th>
+                    <th style="width:80px;">Type</th>
+                    <th style="width:80px;">Price</th>
+                    <th style="width:80px;">Qty</th>
+                    <th style="width:80px;">Status</th>
+                </tr>
+            </ng-template>
+            <ng-template pTemplate="body" let-o>
+                <tr>
+                    <td class="mono">{{o.id}}</td>
+                    <td class="mono">{{o.ts*1000 | date:'medium'}}</td>
+                    <td>{{o.event}}</td>
+                    <td>{{o.symbol}}</td>
+                    <td>{{o.side}}</td>
+                    <td>{{o.type}}</td>
+                    <td class="mono">{{o.price}}</td>
+                    <td class="mono">{{o.qty}}</td>
+                    <td>{{o.status}}</td>
+                </tr>
+            </ng-template>
+        </p-table>
     </div>
 
     <div>
         <h4>Trades (последние)</h4>
         <div *ngIf="loadingT">Загрузка...</div>
-        <table *ngIf="!loadingT" class="tbl">
-            <tr>
-                <th style="width:60px;">ID</th>
-                <th style="width:140px;">TS</th>
-                <th style="width:80px;">Type</th>
-                <th style="width:100px;">Symbol</th>
-                <th style="width:60px;">Side</th>
-                <th style="width:80px;">Price</th>
-                <th style="width:80px;">Qty</th>
-                <th style="width:80px;">PNL</th>
-            </tr>
-            <tr *ngFor="let t of trades">
-                <td class="mono">{{t.id}}</td>
-                <td class="mono">{{t.ts*1000 | date:'medium'}}</td>
-                <td>{{t.type}}</td>
-                <td>{{t.symbol}}</td>
-                <td>{{t.side}}</td>
-                <td class="mono">{{t.price}}</td>
-                <td class="mono">{{t.qty}}</td>
-                <td class="mono" [class.pnl-positive]="(t.pnl||0) > 0" [class.pnl-negative]="(t.pnl||0) < 0">{{t.pnl}}</td>
-            </tr>
-        </table>
+        <p-table *ngIf="!loadingT" [value]="trades" styleClass="tbl">
+            <ng-template pTemplate="header">
+                <tr>
+                    <th style="width:60px;">ID</th>
+                    <th style="width:140px;">TS</th>
+                    <th style="width:80px;">Type</th>
+                    <th style="width:100px;">Symbol</th>
+                    <th style="width:60px;">Side</th>
+                    <th style="width:80px;">Price</th>
+                    <th style="width:80px;">Qty</th>
+                    <th style="width:80px;">PNL</th>
+                </tr>
+            </ng-template>
+            <ng-template pTemplate="body" let-t>
+                <tr>
+                    <td class="mono">{{t.id}}</td>
+                    <td class="mono">{{t.ts*1000 | date:'medium'}}</td>
+                    <td>{{t.type}}</td>
+                    <td>{{t.symbol}}</td>
+                    <td>{{t.side}}</td>
+                    <td class="mono">{{t.price}}</td>
+                    <td class="mono">{{t.qty}}</td>
+                    <td class="mono" [class.pnl-positive]="(t.pnl||0) > 0" [class.pnl-negative]="(t.pnl||0) < 0">{{t.pnl}}</td>
+                </tr>
+            </ng-template>
+        </p-table>
     </div>
 </div>

--- a/frontend/src/app/components/logs/logs.component.html
+++ b/frontend/src/app/components/logs/logs.component.html
@@ -1,27 +1,27 @@
 <div class="logs">
     <div class="pane" #pane>
-        <table class="tbl">
-            <thead>
-            <tr>
-                <th style="width:120px;">Время</th>
-                <th style="width:110px;">Тип</th>
-                <th>Сообщение</th>
-            </tr>
-            </thead>
-            <tbody>
-            <tr *ngFor="let r of rows">
-                <td class="mono">{{ r.ts | date:'mediumTime' }}</td>
-                <td class="mono type"
-                    [class.type-status]="r.type==='status'"
-                    [class.type-diag]="r.type==='diag'"
-                    [class.type-stats]="r.type==='stats'"
-                    [class.type-order]="r.type==='order_event'"
-                    [class.type-trade]="r.type==='trade'">
-                    {{ r.type }}
-                </td>
-                <td class="txt">{{ r.text }}</td>
-            </tr>
-            </tbody>
-        </table>
+        <p-table [value]="rows" styleClass="tbl">
+            <ng-template pTemplate="header">
+                <tr>
+                    <th style="width:120px;">Время</th>
+                    <th style="width:110px;">Тип</th>
+                    <th>Сообщение</th>
+                </tr>
+            </ng-template>
+            <ng-template pTemplate="body" let-r>
+                <tr>
+                    <td class="mono">{{ r.ts | date:'mediumTime' }}</td>
+                    <td class="mono type"
+                        [class.type-status]="r.type==='status'"
+                        [class.type-diag]="r.type==='diag'"
+                        [class.type-stats]="r.type==='stats'"
+                        [class.type-order]="r.type==='order_event'"
+                        [class.type-trade]="r.type==='trade'">
+                        {{ r.type }}
+                    </td>
+                    <td class="txt">{{ r.text }}</td>
+                </tr>
+            </ng-template>
+        </p-table>
     </div>
 </div>

--- a/frontend/src/app/components/orders-widget/orders-widget.component.html
+++ b/frontend/src/app/components/orders-widget/orders-widget.component.html
@@ -4,22 +4,24 @@
     </div>
 
     <div class="scroll">
-        <table class="tbl">
-            <thead>
-            <tr><th>ID</th><th>Side</th><th>Price</th><th>Qty</th><th>Status</th><th>Time</th></tr>
-            </thead>
-            <tbody>
-            <tr *ngFor="let o of orders; trackBy: trackId">
-                <td class="mono">{{ o.id }}</td>
-                <td [class.buy]="o.side==='BUY'" [class.sell]="o.side==='SELL'">{{ o.side }}</td>
-                <td class="mono">{{ o.price | number:'1.2-6' }}</td>
-                <td class="mono">{{ o.qty | number:'1.6-6' }}</td>
-                <td>{{ o.status }}</td>
-                <td class="mono">{{ o.ts | date:'mediumTime' }}</td>
-            </tr>
-            <tr *ngIf="orders.length===0"><td colspan="6" class="muted">пока пусто</td></tr>
-            </tbody>
-        </table>
+        <p-table [value]="orders" styleClass="tbl" [trackBy]="trackId">
+            <ng-template pTemplate="header">
+                <tr><th>ID</th><th>Side</th><th>Price</th><th>Qty</th><th>Status</th><th>Time</th></tr>
+            </ng-template>
+            <ng-template pTemplate="body" let-o>
+                <tr>
+                    <td class="mono">{{ o.id }}</td>
+                    <td [class.buy]="o.side==='BUY'" [class.sell]="o.side==='SELL'">{{ o.side }}</td>
+                    <td class="mono">{{ o.price | number:'1.2-6' }}</td>
+                    <td class="mono">{{ o.qty | number:'1.6-6' }}</td>
+                    <td>{{ o.status }}</td>
+                    <td class="mono">{{ o.ts | date:'mediumTime' }}</td>
+                </tr>
+            </ng-template>
+            <ng-template pTemplate="emptymessage">
+                <tr><td colspan="6" class="muted">пока пусто</td></tr>
+            </ng-template>
+        </p-table>
     </div>
 </div>
 

--- a/frontend/src/app/components/scanner/scanner.component.html
+++ b/frontend/src/app/components/scanner/scanner.component.html
@@ -1,12 +1,12 @@
 <div class="group">
   <div class="group-title">Scanner Settings</div>
   <div class="form-grid">
-    <label>Quote <input [(ngModel)]="cfg.quote"></label>
-    <label>Min price <input type="number" [(ngModel)]="cfg.min_price"></label>
-    <label>Min vol USDT 24h <input type="number" [(ngModel)]="cfg.min_vol_usdt_24h"></label>
-    <label>Top by volume <input type="number" [(ngModel)]="cfg.top_by_volume"></label>
-    <label>Max pairs <input type="number" [(ngModel)]="cfg.max_pairs"></label>
-    <label>Min spread bps <input type="number" [(ngModel)]="cfg.min_spread_bps"></label>
+    <label>Quote <input pInputText [(ngModel)]="cfg.quote"></label>
+    <label>Min price <p-inputNumber [(ngModel)]="cfg.min_price"></p-inputNumber></label>
+    <label>Min vol USDT 24h <p-inputNumber [(ngModel)]="cfg.min_vol_usdt_24h"></p-inputNumber></label>
+    <label>Top by volume <p-inputNumber [(ngModel)]="cfg.top_by_volume"></p-inputNumber></label>
+    <label>Max pairs <p-inputNumber [(ngModel)]="cfg.max_pairs"></p-inputNumber></label>
+    <label>Min spread bps <p-inputNumber [(ngModel)]="cfg.min_spread_bps"></p-inputNumber></label>
   </div>
   <p-button (onClick)="scan()" [disabled]="loading" [label]="loading ? 'Scanning…' : 'Scan'"></p-button>
 </div>
@@ -17,16 +17,16 @@
   <div class="muted">Spread {{ best.spread_bps | number:'1.2-2' }} bps; Vol {{ best.vol_usdt_24h | number:'1.0-0' }}</div>
 </div>
 
-<table class="tbl small" *ngIf="top.length">
-  <thead>
-  <tr><th>Symbol</th><th>Spread bps</th><th>Vol USDT</th><th>Score</th></tr>
-  </thead>
-  <tbody>
-  <tr *ngFor="let s of top">
-    <td class="mono">{{ s.symbol }}</td>
-    <td class="mono">{{ s.spread_bps | number:'1.2-2' }}</td>
-    <td class="mono">{{ s.vol_usdt_24h | number:'1.0-0' }}</td>
-    <td class="mono">{{ s.score | number:'1.2-2' }}</td>
-  </tr>
-  </tbody>
-</table>
+<p-table *ngIf="top.length" [value]="top" styleClass="tbl small">
+  <ng-template pTemplate="header">
+    <tr><th>Symbol</th><th>Spread bps</th><th>Vol USDT</th><th>Score</th></tr>
+  </ng-template>
+  <ng-template pTemplate="body" let-s>
+    <tr>
+      <td class="mono">{{ s.symbol }}</td>
+      <td class="mono">{{ s.spread_bps | number:'1.2-2' }}</td>
+      <td class="mono">{{ s.vol_usdt_24h | number:'1.0-0' }}</td>
+      <td class="mono">{{ s.score | number:'1.2-2' }}</td>
+    </tr>
+  </ng-template>
+</p-table>

--- a/frontend/src/app/core/theme/theme-toggle.component.ts
+++ b/frontend/src/app/core/theme/theme-toggle.component.ts
@@ -1,15 +1,14 @@
 import { Component, inject } from '@angular/core';
 import { NgIf } from '@angular/common';
 import { ThemeService } from './theme.service';
+import { ButtonModule } from 'primeng/button';
 
 @Component({
   selector: 'app-theme-toggle',
   standalone: true,
-  imports: [NgIf],
+  imports: [NgIf, ButtonModule],
   template: `
-    <button type="button" (click)="theme.toggle()" class="toggle">
-      🌓 <span *ngIf="theme.current==='dark'">Dark</span><span *ngIf="theme.current==='light'">Light</span>
-    </button>
+    <p-button type="button" (onClick)="theme.toggle()" class="toggle" [label]="theme.current==='dark' ? '🌓 Dark' : '🌓 Light'"></p-button>
   `,
   styles: [`
     .toggle {

--- a/frontend/src/app/features/analytics/analytics.component.ts
+++ b/frontend/src/app/features/analytics/analytics.component.ts
@@ -3,48 +3,44 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { ApiService } from '../../core/services/api.service';
 import { firstValueFrom } from 'rxjs';
+import { PrimeNgModule } from '../../prime-ng.module';
 
 @Component({
   standalone: true,
   selector: 'app-analytics',
-  imports: [CommonModule, FormsModule],
+  imports: [CommonModule, FormsModule, PrimeNgModule],
   template: `
   <div class="p-4">
     <h2 class="text-xl font-semibold mb-4">Analytics</h2>
     <div class="grid grid-cols-5 gap-3 items-end mb-4">
       <div>
         <label class="block text-sm mb-1">Exchange</label>
-        <select class="border rounded p-2 w-full" [(ngModel)]="exchange">
-          <option value="binance">binance</option>
-          <option value="bybit">bybit</option>
-        </select>
+        <p-dropdown class="w-full" [(ngModel)]="exchange" [options]="exchangeOptions"></p-dropdown>
       </div>
       <div>
         <label class="block text-sm mb-1">Category</label>
-        <select class="border rounded p-2 w-full" [(ngModel)]="category">
-          <option value="usdt">usdt</option>
-          <option value="spot">spot</option>
-          <option value="linear">linear</option>
-        </select>
+        <p-dropdown class="w-full" [(ngModel)]="category" [options]="categoryOptions"></p-dropdown>
       </div>
       <div>
         <label class="block text-sm mb-1">Symbol</label>
-        <input class="border rounded p-2 w-full" [(ngModel)]="symbol">
+        <input pInputText class="w-full" [(ngModel)]="symbol">
       </div>
       <div class="col-span-2">
-        <button class="px-3 py-2 rounded bg-black text-white" (click)="load()">Load</button>
+        <p-button label="Load" (onClick)="load()" severity="primary"></p-button>
       </div>
     </div>
 
     <div class="grid md:grid-cols-2 gap-6">
       <div>
         <h3 class="font-medium mb-2">Daily PnL (cash)</h3>
-        <table class="min-w-full text-sm">
-          <thead><tr class="text-left text-gray-500"><th>Day</th><th>Cash</th></tr></thead>
-          <tbody>
-            @for (d of daily(); track d.day) { <tr class="border-t"><td>{{ d.day }}</td><td>{{ d.cash | number:'1.2-2' }}</td></tr> }
-          </tbody>
-        </table>
+        <p-table [value]="daily()" class="min-w-full text-sm">
+          <ng-template pTemplate="header">
+            <tr class="text-left text-gray-500"><th>Day</th><th>Cash</th></tr>
+          </ng-template>
+          <ng-template pTemplate="body" let-d>
+            <tr class="border-t"><td>{{ d.day }}</td><td>{{ d.cash | number:'1.2-2' }}</td></tr>
+          </ng-template>
+        </p-table>
       </div>
       <div>
         <h3 class="font-medium mb-2">Equity</h3>
@@ -61,6 +57,15 @@ export class AnalyticsComponent {
   exchange = 'binance'; category = 'usdt'; symbol = 'BTCUSDT';
   daily = signal<any[]>([]);
   equity = signal<{ts:number;equity:number}[]>([]);
+  exchangeOptions = [
+    { label: 'binance', value: 'binance' },
+    { label: 'bybit', value: 'bybit' }
+  ];
+  categoryOptions = [
+    { label: 'usdt', value: 'usdt' },
+    { label: 'spot', value: 'spot' },
+    { label: 'linear', value: 'linear' }
+  ];
 
   scaleX(arr:any[], i:number) { return Math.round((i/(Math.max(arr.length-1,1)))*380)+10; }
   scaleY(arr:any[], y:number) {

--- a/frontend/src/app/features/audit/audit.component.ts
+++ b/frontend/src/app/features/audit/audit.component.ts
@@ -3,26 +3,27 @@ import { CommonModule } from '@angular/common';
 import { AuthService } from '../../core/services/auth.service';
 import { ApiService } from '../../core/services/api.service';
 import { firstValueFrom } from 'rxjs';
+import { PrimeNgModule } from '../../prime-ng.module';
 
 @Component({
   standalone: true,
   selector: 'app-audit',
-  imports: [CommonModule],
+  imports: [CommonModule, PrimeNgModule],
   template: `
   <div class="p-4">
     <h2 class="text-xl font-semibold mb-4">Audit Logs</h2>
     <p class="text-sm text-gray-600 mb-4">Only admins can view this page.</p>
     <div *ngIf="auth.role()==='admin'; else denied">
-      <table class="min-w-full text-sm">
-        <thead><tr class="text-left text-gray-500"><th>Time</th><th>Route</th><th>Method</th><th>Status</th><th>Actor</th></tr></thead>
-        <tbody>
-          @for (a of logs(); track a.id) {
-            <tr class="border-t">
-              <td>{{ a.ts }}</td><td>{{ a.route }}</td><td>{{ a.method }}</td><td>{{ a.status }}</td><td>{{ a.actor }}</td>
-            </tr>
-          }
-        </tbody>
-      </table>
+      <p-table [value]="logs()" class="min-w-full text-sm">
+        <ng-template pTemplate="header">
+          <tr class="text-left text-gray-500"><th>Time</th><th>Route</th><th>Method</th><th>Status</th><th>Actor</th></tr>
+        </ng-template>
+        <ng-template pTemplate="body" let-a>
+          <tr class="border-t">
+            <td>{{ a.ts }}</td><td>{{ a.route }}</td><td>{{ a.method }}</td><td>{{ a.status }}</td><td>{{ a.actor }}</td>
+          </tr>
+        </ng-template>
+      </p-table>
     </div>
     <ng-template #denied><div class="text-rose-600">Forbidden</div></ng-template>
   </div>

--- a/frontend/src/app/features/backtest/backtest.component.ts
+++ b/frontend/src/app/features/backtest/backtest.component.ts
@@ -2,45 +2,38 @@ import { Component, inject, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { ApiService } from '../../core/services/api.service';
+import { PrimeNgModule } from '../../prime-ng.module';
 
 @Component({
   standalone: true,
   selector: 'app-backtest',
-  imports: [CommonModule, FormsModule],
+  imports: [CommonModule, FormsModule, PrimeNgModule],
   template: `
   <div class="p-4 max-w-3xl">
     <h2 class="text-xl font-semibold mb-4">Backtest</h2>
     <div class="grid grid-cols-6 gap-3 items-end mb-4">
       <div>
         <label class="block text-sm mb-1">Exchange</label>
-        <select class="border rounded p-2 w-full" [(ngModel)]="cfg.exchange">
-          <option value="mock">mock</option>
-          <option value="bybit">bybit</option>
-          <option value="binance">binance</option>
-        </select>
+        <p-dropdown class="w-full" [(ngModel)]="cfg.exchange" [options]="exchangeOptions"></p-dropdown>
       </div>
       <div>
         <label class="block text-sm mb-1">Category</label>
-        <select class="border rounded p-2 w-full" [(ngModel)]="cfg.category">
-          <option value="spot">spot</option>
-          <option value="linear">linear</option>
-          <option value="usdt">usdt</option>
-        </select>
+        <p-dropdown class="w-full" [(ngModel)]="cfg.category" [options]="categoryOptions"></p-dropdown>
       </div>
       <div>
         <label class="block text-sm mb-1">Symbol</label>
-        <input class="border rounded p-2 w-full" [(ngModel)]="cfg.symbol">
+        <input pInputText class="w-full" [(ngModel)]="cfg.symbol">
       </div>
       <div>
         <label class="block text-sm mb-1">Timeframe</label>
-        <input class="border rounded p-2 w-full" [(ngModel)]="cfg.tf">
+        <input pInputText class="w-full" [(ngModel)]="cfg.tf">
       </div>
       <div>
         <label class="block text-sm mb-1">Limit</label>
-        <input type="number" class="border rounded p-2 w-full" [(ngModel)]="cfg.limit">
+        <p-inputNumber class="w-full" [(ngModel)]="cfg.limit"></p-inputNumber>
       </div>
       <div>
-        <button class="px-3 py-2 rounded bg-black text-white w-full" (click)="run()">Run</button>
+        <p-button label="Run" (onClick)="run()" severity="primary" class="w-full"></p-button>
       </div>
     </div>
 
@@ -56,6 +49,16 @@ export class BacktestComponent {
   api = inject(ApiService);
   cfg: any = { exchange: 'mock', category: 'spot', symbol: 'BTCUSDT', tf: '1m', limit: 500 };
   result = signal<any | null>(null);
+  exchangeOptions = [
+    { label: 'mock', value: 'mock' },
+    { label: 'bybit', value: 'bybit' },
+    { label: 'binance', value: 'binance' }
+  ];
+  categoryOptions = [
+    { label: 'spot', value: 'spot' },
+    { label: 'linear', value: 'linear' },
+    { label: 'usdt', value: 'usdt' }
+  ];
 
   async run() {
     this.result.set(await this.api.runBacktest(this.cfg));

--- a/frontend/src/app/features/keys/keys.component.ts
+++ b/frontend/src/app/features/keys/keys.component.ts
@@ -2,36 +2,33 @@ import { Component, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { ApiService } from '../../core/services/api.service';
+import { PrimeNgModule } from '../../prime-ng.module';
 
 @Component({
   standalone: true,
   selector: 'app-keys',
-  imports: [CommonModule, FormsModule],
+  imports: [CommonModule, FormsModule, PrimeNgModule],
   template: `
   <div class="p-4 max-w-xl">
     <h2 class="text-xl font-semibold mb-4">Exchange API Keys</h2>
     <div class="grid gap-3">
       <label class="block">
         <span class="text-sm">Exchange</span>
-        <select class="border rounded p-2 w-full" [(ngModel)]="exchange">
-          <option value="binance">binance</option>
-        </select>
+        <p-dropdown class="w-full" [(ngModel)]="exchange" [options]="exchangeOptions"></p-dropdown>
       </label>
       <label class="block">
         <span class="text-sm">Category</span>
-        <select class="border rounded p-2 w-full" [(ngModel)]="category">
-          <option value="usdt">usdt (futures)</option>
-        </select>
+        <p-dropdown class="w-full" [(ngModel)]="category" [options]="categoryOptions"></p-dropdown>
       </label>
       <label class="block">
         <span class="text-sm">API Key</span>
-        <input class="border rounded p-2 w-full" [(ngModel)]="api_key">
+        <input pInputText class="w-full" [(ngModel)]="api_key">
       </label>
       <label class="block">
         <span class="text-sm">API Secret</span>
-        <input class="border rounded p-2 w-full" [(ngModel)]="api_secret">
+        <input pInputText class="w-full" [(ngModel)]="api_secret">
       </label>
-      <button class="px-3 py-2 rounded bg-black text-white w-fit" (click)="save()">Save</button>
+      <p-button label="Save" (onClick)="save()" severity="primary" class="w-fit"></p-button>
     </div>
     <p class="text-sm text-gray-600 mt-4">Ключи шифруются (Fernet) и хранятся в БД. Для прод — задайте ENCRYPTION_KEY.</p>
   </div>
@@ -43,6 +40,8 @@ export class KeysComponent {
   category = 'usdt';
   api_key = '';
   api_secret = '';
+  exchangeOptions = [ { label: 'binance', value: 'binance' } ];
+  categoryOptions = [ { label: 'usdt (futures)', value: 'usdt' } ];
 
   async save() {
     await this.api.saveKeys({ exchange: this.exchange, category: this.category, api_key: this.api_key, api_secret: this.api_secret });

--- a/frontend/src/app/features/orders/orders.component.ts
+++ b/frontend/src/app/features/orders/orders.component.ts
@@ -1,45 +1,46 @@
 import { Component, inject, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ApiService } from '../../core/services/api.service';
+import { PrimeNgModule } from '../../prime-ng.module';
 
 @Component({
   standalone: true,
   selector: 'app-orders',
-  imports: [CommonModule],
+  imports: [CommonModule, PrimeNgModule],
   template: `
   <div class="p-4">
     <h2 class="text-xl font-semibold mb-4">Orders & Fills</h2>
     <div class="grid md:grid-cols-2 gap-6">
       <div>
         <h3 class="font-medium mb-2">Orders (latest)</h3>
-        <table class="min-w-full text-sm">
-          <thead><tr class="text-left text-gray-500">
-            <th>Time</th><th>Symbol</th><th>Side</th><th>Qty</th><th>Price</th><th>Status</th>
-          </tr></thead>
-          <tbody>
-            @for (o of orders(); track o.id) {
-              <tr class="border-t">
-                <td>{{ o.created_at }}</td><td>{{ o.symbol }}</td><td>{{ o.side }}</td>
-                <td>{{ o.qty }}</td><td>{{ o.price ?? '-' }}</td><td>{{ o.status }}</td>
-              </tr>
-            }
-          </tbody>
-        </table>
+        <p-table [value]="orders()" class="min-w-full text-sm">
+          <ng-template pTemplate="header">
+            <tr class="text-left text-gray-500">
+              <th>Time</th><th>Symbol</th><th>Side</th><th>Qty</th><th>Price</th><th>Status</th>
+            </tr>
+          </ng-template>
+          <ng-template pTemplate="body" let-o>
+            <tr class="border-t">
+              <td>{{ o.created_at }}</td><td>{{ o.symbol }}</td><td>{{ o.side }}</td>
+              <td>{{ o.qty }}</td><td>{{ o.price ?? '-' }}</td><td>{{ o.status }}</td>
+            </tr>
+          </ng-template>
+        </p-table>
       </div>
       <div>
         <h3 class="font-medium mb-2">Fills (latest)</h3>
-        <table class="min-w-full text-sm">
-          <thead><tr class="text-left text-gray-500">
-            <th>TS</th><th>Symbol</th><th>Side</th><th>Qty</th><th>Price</th>
-          </tr></thead>
-          <tbody>
-            @for (f of fills(); track f.id) {
-              <tr class="border-t">
-                <td>{{ f.ts }}</td><td>{{ f.symbol }}</td><td>{{ f.side }}</td><td>{{ f.qty }}</td><td>{{ f.price }}</td>
-              </tr>
-            }
-          </tbody>
-        </table>
+        <p-table [value]="fills()" class="min-w-full text-sm">
+          <ng-template pTemplate="header">
+            <tr class="text-left text-gray-500">
+              <th>TS</th><th>Symbol</th><th>Side</th><th>Qty</th><th>Price</th>
+            </tr>
+          </ng-template>
+          <ng-template pTemplate="body" let-f>
+            <tr class="border-t">
+              <td>{{ f.ts }}</td><td>{{ f.symbol }}</td><td>{{ f.side }}</td><td>{{ f.qty }}</td><td>{{ f.price }}</td>
+            </tr>
+          </ng-template>
+        </p-table>
       </div>
     </div>
   </div>

--- a/frontend/src/app/features/portfolio/portfolio.component.ts
+++ b/frontend/src/app/features/portfolio/portfolio.component.ts
@@ -2,36 +2,37 @@ import { Component, inject, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ApiService } from '../../core/services/api.service';
 import { WsService } from '../../core/services/ws.service';
+import { PrimeNgModule } from '../../prime-ng.module';
 
 @Component({
   standalone: true,
   selector: 'app-portfolio',
-  imports: [CommonModule],
+  imports: [CommonModule, PrimeNgModule],
   template: `
   <div class="p-4">
     <h2 class="text-xl font-semibold mb-4">Portfolio</h2>
     <div class="grid md:grid-cols-2 gap-6">
       <div>
         <h3 class="font-medium mb-2">Balances</h3>
-        <table class="min-w-full text-sm">
-          <thead><tr class="text-left text-gray-500"><th>Asset</th><th>Free</th><th>Locked</th></tr></thead>
-          <tbody>
-            @for (b of balances(); track b.id) {
-              <tr class="border-t"><td>{{ b.asset }}</td><td>{{ b.free }}</td><td>{{ b.locked }}</td></tr>
-            }
-          </tbody>
-        </table>
+        <p-table [value]="balances()" class="min-w-full text-sm">
+          <ng-template pTemplate="header">
+            <tr class="text-left text-gray-500"><th>Asset</th><th>Free</th><th>Locked</th></tr>
+          </ng-template>
+          <ng-template pTemplate="body" let-b>
+            <tr class="border-t"><td>{{ b.asset }}</td><td>{{ b.free }}</td><td>{{ b.locked }}</td></tr>
+          </ng-template>
+        </p-table>
       </div>
       <div>
         <h3 class="font-medium mb-2">Positions</h3>
-        <table class="min-w-full text-sm">
-          <thead><tr class="text-left text-gray-500"><th>Symbol</th><th>Qty</th><th>Avg Price</th></tr></thead>
-          <tbody>
-            @for (p of positions(); track p.id) {
-              <tr class="border-t"><td>{{ p.symbol }}</td><td>{{ p.qty }}</td><td>{{ p.avg_price }}</td></tr>
-            }
-          </tbody>
-        </table>
+        <p-table [value]="positions()" class="min-w-full text-sm">
+          <ng-template pTemplate="header">
+            <tr class="text-left text-gray-500"><th>Symbol</th><th>Qty</th><th>Avg Price</th></tr>
+          </ng-template>
+          <ng-template pTemplate="body" let-p>
+            <tr class="border-t"><td>{{ p.symbol }}</td><td>{{ p.qty }}</td><td>{{ p.avg_price }}</td></tr>
+          </ng-template>
+        </p-table>
       </div>
     </div>
 

--- a/frontend/src/app/features/risk/risk.component.ts
+++ b/frontend/src/app/features/risk/risk.component.ts
@@ -18,11 +18,11 @@ import { ToastService } from '../../shared/ui/toast.service';
         <div class="grid grid-cols-2 gap-2">
           <p-dropdown [options]="strategies" optionLabel="id" optionValue="id" [(ngModel)]="sid"></p-dropdown>
           <p-button label="Load" (onClick)="load()" severity="secondary"></p-button>
-          <label>max_active_orders</label><input type="number" class="border rounded p-2" [(ngModel)]="pol.max_active_orders">
-          <label>max_dd</label><input type="number" step="0.01" class="border rounded p-2" [(ngModel)]="pol.max_dd">
-          <label>max_leverage</label><input type="number" class="border rounded p-2" [(ngModel)]="pol.max_leverage">
-          <label>max_notional_per_symbol.BTCUSDT</label><input type="number" class="border rounded p-2" [(ngModel)]="pol.max_notional_per_symbol.BTCUSDT">
-          <label>max_pos_qty_per_symbol.BTCUSDT</label><input type="number" step="0.0001" class="border rounded p-2" [(ngModel)]="pol.max_pos_qty_per_symbol.BTCUSDT">
+          <label>max_active_orders</label><p-inputNumber [(ngModel)]="pol.max_active_orders"></p-inputNumber>
+          <label>max_dd</label><p-inputNumber [(ngModel)]="pol.max_dd" [step]="0.01"></p-inputNumber>
+          <label>max_leverage</label><p-inputNumber [(ngModel)]="pol.max_leverage"></p-inputNumber>
+          <label>max_notional_per_symbol.BTCUSDT</label><p-inputNumber [(ngModel)]="pol.max_notional_per_symbol.BTCUSDT"></p-inputNumber>
+          <label>max_pos_qty_per_symbol.BTCUSDT</label><p-inputNumber [(ngModel)]="pol.max_pos_qty_per_symbol.BTCUSDT" [step]="0.0001"></p-inputNumber>
           <div class="col-span-2">
             <p-button label="Save" (onClick)="save()" severity="primary"></p-button>
           </div>

--- a/frontend/src/app/features/strategies/strategies.component.ts
+++ b/frontend/src/app/features/strategies/strategies.component.ts
@@ -6,16 +6,17 @@ import { JsonSchemaFormComponent } from '../../shared/json-schema-form.component
 import { ApiService } from '../../core/services/api.service';
 import { firstValueFrom } from 'rxjs';
 import { MessageService } from 'primeng/api';
+import { PrimeNgModule } from '../../prime-ng.module';
 
 @Component({
   standalone: true,
   selector: 'app-strategies',
-  imports: [CommonModule, FormsModule, RouterLink, JsonSchemaFormComponent],
+  imports: [CommonModule, FormsModule, RouterLink, JsonSchemaFormComponent, PrimeNgModule],
   template: `
   <div class="p-4">
     <div class="flex items-center justify-between mb-4">
       <h2 class="text-xl font-semibold">Strategies</h2>
-      <button class="px-3 py-2 rounded bg-black text-white" (click)="openCreate=true">Create</button>
+      <p-button label="Create" (onClick)="openCreate=true" severity="primary"></p-button>
     </div>
 
     <div class="grid md:grid-cols-3 gap-4">
@@ -36,31 +37,27 @@ import { MessageService } from 'primeng/api';
       <div class="bg-white rounded p-4 w-[700px] max-w-[95vw]">
         <div class="flex items-center justify-between mb-3">
           <div class="font-medium">Create Strategy</div>
-          <button class="text-sm" (click)="openCreate=false">✕</button>
+          <p-button label="✕" (onClick)="openCreate=false" text></p-button>
         </div>
         <div class="grid grid-cols-2 gap-3">
           <div>
             <label class="block text-sm mb-1">Strategy</label>
-            <select class="border rounded p-2 w-full" [(ngModel)]="sid" (ngModelChange)="loadSchema()">
-              @for (s of list(); track s.id) {
-                <option [value]="s.id">{{ s.id }}</option>
-              }
-            </select>
+            <p-dropdown class="w-full" [options]="list()" optionLabel="id" optionValue="id" [(ngModel)]="sid" (onChange)="loadSchema()"></p-dropdown>
           </div>
           <div>
             <label class="block text-sm mb-1">Exchange</label>
-            <input class="border rounded p-2 w-full" [(ngModel)]="exchange" />
+            <input pInputText class="w-full" [(ngModel)]="exchange" />
           </div>
           <div>
             <label class="block text-sm mb-1">Symbol</label>
-            <input class="border rounded p-2 w-full" [(ngModel)]="symbol" />
+            <input pInputText class="w-full" [(ngModel)]="symbol" />
           </div>
           <div class="col-span-2">
             <app-json-schema-form [schema]="schema()" [(model)]="cfg"></app-json-schema-form>
           </div>
           <div class="col-span-2 mt-2 flex gap-2">
-            <button class="px-3 py-2 rounded bg-black text-white" (click)="create()">Create & Start</button>
-            <button class="px-3 py-2 rounded" (click)="openCreate=false">Cancel</button>
+            <p-button label="Create & Start" (onClick)="create()" severity="primary"></p-button>
+            <p-button label="Cancel" (onClick)="openCreate=false"></p-button>
           </div>
         </div>
       </div>

--- a/frontend/src/app/features/strategy-detail/strategy-detail.component.ts
+++ b/frontend/src/app/features/strategy-detail/strategy-detail.component.ts
@@ -2,21 +2,22 @@ import { Component, inject, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ActivatedRoute } from '@angular/router';
 import { ApiService } from '../../core/services/api.service';
+import { PrimeNgModule } from '../../prime-ng.module';
 
 @Component({
   standalone: true,
   selector: 'app-strategy-detail',
-  imports: [CommonModule],
+  imports: [CommonModule, PrimeNgModule],
   template: `
   <div class="p-4">
     <div class="flex items-center justify-between">
       <h2 class="text-xl font-semibold">Strategy: {{ sid }}</h2>
-      <a class="px-3 py-2 rounded bg-black text-white" [href]="csvUrl()" target="_blank">Download CSV</a>
+      <p-button label="Download CSV" [link]="true" [href]="csvUrl()" target="_blank" severity="secondary"></p-button>
     </div>
     @if (error()) {
       <div class="mt-4 flex items-center gap-2">
         <div class="text-yellow-600">{{ error() }}</div>
-        <button class="px-3 py-2 rounded bg-black text-white" (click)="load()">Retry</button>
+        <p-button label="Retry" (onClick)="load()" severity="primary"></p-button>
       </div>
     }
     <div class="grid md:grid-cols-2 gap-6 mt-4">
@@ -34,14 +35,14 @@ import { ApiService } from '../../core/services/api.service';
         </div>
         <div class="mt-4 border rounded p-3">
           <div class="font-medium mb-2">Last Fills</div>
-          <table class="w-full text-sm">
-            <thead><tr class="text-left"><th>Time</th><th>Side</th><th>Qty</th><th>Price</th></tr></thead>
-            <tbody>
-              @for (f of fills(); track f.ts) {
-                <tr><td>{{ f.ts }}</td><td>{{ f.side }}</td><td>{{ f.qty }}</td><td>{{ f.price }}</td></tr>
-              }
-            </tbody>
-          </table>
+          <p-table [value]="fills()" class="w-full text-sm">
+            <ng-template pTemplate="header">
+              <tr class="text-left"><th>Time</th><th>Side</th><th>Qty</th><th>Price</th></tr>
+            </ng-template>
+            <ng-template pTemplate="body" let-f>
+              <tr><td>{{ f.ts }}</td><td>{{ f.side }}</td><td>{{ f.qty }}</td><td>{{ f.price }}</td></tr>
+            </ng-template>
+          </p-table>
         </div>
       </div>
       <div>

--- a/frontend/src/app/features/trades/trades.component.ts
+++ b/frontend/src/app/features/trades/trades.component.ts
@@ -3,34 +3,33 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { ApiService } from '../../core/services/api.service';
 import { firstValueFrom } from 'rxjs';
+import { PrimeNgModule } from '../../prime-ng.module';
 
 @Component({
   standalone: true,
   selector: 'app-trades',
-  imports: [CommonModule, FormsModule],
+  imports: [CommonModule, FormsModule, PrimeNgModule],
   template: `
   <div class="p-4">
     <h2 class="text-xl font-semibold mb-3">Trades</h2>
     <div class="grid md:grid-cols-5 gap-2 mb-3">
-      <input class="border rounded p-2 w-full" [(ngModel)]="symbol" placeholder="symbol (e.g. BTCUSDT)">
-      <input class="border rounded p-2 w-full" [(ngModel)]="exchange" placeholder="exchange (binance/bybit)">
-      <input class="border rounded p-2 w-full" [(ngModel)]="category" placeholder="category (spot/usdt/linear)">
-      <select class="border rounded p-2 w-full" [(ngModel)]="strategy_id">
-        <option *ngFor="let s of strategies" [value]="s.id">{{ s.id }}</option>
-      </select>
-      <button class="px-3 py-2 rounded bg-black text-white" (click)="load()">Load</button>
+      <input pInputText class="w-full" [(ngModel)]="symbol" placeholder="symbol (e.g. BTCUSDT)">
+      <input pInputText class="w-full" [(ngModel)]="exchange" placeholder="exchange (binance/bybit)">
+      <input pInputText class="w-full" [(ngModel)]="category" placeholder="category (spot/usdt/linear)">
+      <p-dropdown class="w-full" [options]="strategies" optionLabel="id" optionValue="id" [(ngModel)]="strategy_id"></p-dropdown>
+      <p-button label="Load" (onClick)="load()" severity="primary"></p-button>
     </div>
     <div class="mb-3">
       <a class="underline" [href]="csvUrl()" target="_blank">Download realized CSV</a>
     </div>
-    <table class="w-full text-sm border">
-      <thead><tr class="text-left"><th>Time</th><th>Symbol</th><th>Side</th><th>Qty</th><th>Price</th><th>Exchange</th><th>Category</th><th>Strategy</th></tr></thead>
-      <tbody>
-        @for (f of items(); track f.ts) {
-          <tr><td>{{ f.ts }}</td><td>{{ f.symbol }}</td><td>{{ f.side }}</td><td>{{ f.qty }}</td><td>{{ f.price }}</td><td>{{ f.exchange }}</td><td>{{ f.category }}</td><td>{{ f.strategy_id }}</td></tr>
-        }
-      </tbody>
-    </table>
+    <p-table [value]="items()" class="w-full text-sm border">
+      <ng-template pTemplate="header">
+        <tr class="text-left"><th>Time</th><th>Symbol</th><th>Side</th><th>Qty</th><th>Price</th><th>Exchange</th><th>Category</th><th>Strategy</th></tr>
+      </ng-template>
+      <ng-template pTemplate="body" let-f>
+        <tr><td>{{ f.ts }}</td><td>{{ f.symbol }}</td><td>{{ f.side }}</td><td>{{ f.qty }}</td><td>{{ f.price }}</td><td>{{ f.exchange }}</td><td>{{ f.category }}</td><td>{{ f.strategy_id }}</td></tr>
+      </ng-template>
+    </p-table>
   </div>
   `
 })

--- a/frontend/src/app/pages/dashboard.page.ts
+++ b/frontend/src/app/pages/dashboard.page.ts
@@ -45,15 +45,15 @@ import { PrimeNgModule } from '../prime-ng.module';
         </div>
         <div>
           <label class="block text-sm mb-1">Exchange</label>
-          <input class="border rounded p-2 w-full" [(ngModel)]="exchange" />
+          <input pInputText class="w-full" [(ngModel)]="exchange" />
         </div>
         <div>
           <label class="block text-sm mb-1">Symbol</label>
-          <input class="border rounded p-2 w-full" [(ngModel)]="symbol" />
+          <input pInputText class="w-full" [(ngModel)]="symbol" />
         </div>
         <div>
           <label class="block text-sm mb-1">Risk Profile</label>
-          <input class="border rounded p-2 w-full" [(ngModel)]="risk" />
+          <input pInputText class="w-full" [(ngModel)]="risk" />
         </div>
         <div class="flex gap-2 mt-2">
           <p-button label="Start" (onClick)="start()" severity="primary"></p-button>

--- a/frontend/src/app/pages/history.page.ts
+++ b/frontend/src/app/pages/history.page.ts
@@ -3,74 +3,75 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { OrderHistoryItem, TradeHistoryItem } from '../models';
 import { ApiService } from '../core/services/api.service';
+import { PrimeNgModule } from '../prime-ng.module';
 
 @Component({
     selector: 'app-history',
     standalone: true,
-    imports: [CommonModule, FormsModule],
+    imports: [CommonModule, FormsModule, PrimeNgModule],
     template: `
         <h1>History</h1>
         <div class="section">
             <h2>Orders</h2>
             <div class="filters">
-                <input [(ngModel)]="orderSymbol" placeholder="Symbol" />
-                <select [(ngModel)]="orderSide">
-                    <option value="">All Sides</option>
-                    <option value="buy">Buy</option>
-                    <option value="sell">Sell</option>
-                </select>
+                <input pInputText [(ngModel)]="orderSymbol" placeholder="Symbol" />
+                <p-dropdown [(ngModel)]="orderSide" [options]="sideOptions"></p-dropdown>
             </div>
-            <table class="tbl">
-                <tr>
-                    <th>Time</th>
-                    <th>Symbol</th>
-                    <th>Side</th>
-                    <th>Price</th>
-                    <th>Qty</th>
-                </tr>
-                <tr *ngFor="let o of filteredOrders">
-                    <td>{{ o.ts * 1000 | date:'medium' }}</td>
-                    <td>{{ o.symbol }}</td>
-                    <td>{{ o.side }}</td>
-                    <td>{{ o.price }}</td>
-                    <td>{{ o.qty }}</td>
-                </tr>
-            </table>
+            <p-table [value]="filteredOrders" class="tbl">
+                <ng-template pTemplate="header">
+                    <tr>
+                        <th>Time</th>
+                        <th>Symbol</th>
+                        <th>Side</th>
+                        <th>Price</th>
+                        <th>Qty</th>
+                    </tr>
+                </ng-template>
+                <ng-template pTemplate="body" let-o>
+                    <tr>
+                        <td>{{ o.ts * 1000 | date:'medium' }}</td>
+                        <td>{{ o.symbol }}</td>
+                        <td>{{ o.side }}</td>
+                        <td>{{ o.price }}</td>
+                        <td>{{ o.qty }}</td>
+                    </tr>
+                </ng-template>
+            </p-table>
             <div class="pager">
-                <button (click)="prevOrders()" [disabled]="orderOffset === 0">Prev</button>
-                <button (click)="nextOrders()" [disabled]="orders.length < limit">Next</button>
+                <p-button label="Prev" (onClick)="prevOrders()" [disabled]="orderOffset === 0"></p-button>
+                <p-button label="Next" (onClick)="nextOrders()" [disabled]="orders.length < limit"></p-button>
             </div>
         </div>
 
         <div class="section">
             <h2>Trades</h2>
             <div class="filters">
-                <input [(ngModel)]="tradeSymbol" placeholder="Symbol" />
-                <select [(ngModel)]="tradeSide">
-                    <option value="">All Sides</option>
-                    <option value="buy">Buy</option>
-                    <option value="sell">Sell</option>
-                </select>
+                <input pInputText [(ngModel)]="tradeSymbol" placeholder="Symbol" />
+                <p-dropdown [(ngModel)]="tradeSide" [options]="sideOptions"></p-dropdown>
             </div>
-            <table class="tbl">
-                <tr>
-                    <th>Time</th>
-                    <th>Symbol</th>
-                    <th>Side</th>
-                    <th>Price</th>
-                    <th>Qty</th>
-                </tr>
-                <tr *ngFor="let t of filteredTrades">
-                    <td>{{ t.ts * 1000 | date:'medium' }}</td>
-                    <td>{{ t.symbol }}</td>
-                    <td>{{ t.side }}</td>
-                    <td>{{ t.price }}</td>
-                    <td>{{ t.qty }}</td>
-                </tr>
-            </table>
+            <p-table [value]="filteredTrades" class="tbl">
+                <ng-template pTemplate="header">
+                    <tr>
+                        <th>Time</th>
+                        <th>Symbol</th>
+                        <th>Side</th>
+                        <th>Price</th>
+                        <th>Qty</th>
+                    </tr>
+                </ng-template>
+                <ng-template pTemplate="body" let-t>
+                    <tr>
+                        <td>{{ t.ts * 1000 | date:'medium' }}</td>
+                        <td>{{ t.symbol }}</td>
+                        <td>{{ t.side }}</td>
+                        <td>{{ t.price }}</td>
+                        <td>{{ t.qty }}</td>
+                    </tr>
+                </ng-template>
+            </p-table>
             <div class="pager">
-                <button (click)="prevTrades()" [disabled]="tradeOffset === 0">Prev</button>
-                <button (click)="nextTrades()" [disabled]="trades.length < limit">Next</button>
+                <p-button label="Prev" (onClick)="prevTrades()" [disabled]="tradeOffset === 0"></p-button>
+                <p-button label="Next" (onClick)="nextTrades()" [disabled]="trades.length < limit"></p-button>
             </div>
         </div>
     `
@@ -85,6 +86,11 @@ export class HistoryPage implements OnInit {
     orderSide = '';
     tradeSymbol = '';
     tradeSide = '';
+    sideOptions = [
+        { label: 'All Sides', value: '' },
+        { label: 'Buy', value: 'buy' },
+        { label: 'Sell', value: 'sell' },
+    ];
 
     constructor(private api: ApiService) {}
 

--- a/frontend/src/app/pages/logs.page.ts
+++ b/frontend/src/app/pages/logs.page.ts
@@ -3,6 +3,7 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { ButtonModule } from 'primeng/button';
 import { CardModule } from 'primeng/card';
+import { InputTextModule } from 'primeng/inputtext';
 import { Subscription } from 'rxjs';
 import { WsService } from '../core/services/ws.service';
 import { ApiService } from '../core/services/api.service';
@@ -11,7 +12,7 @@ import { ActivatedRoute } from '@angular/router';
 @Component({
   selector: 'app-logs',
   standalone: true,
-  imports: [CommonModule, FormsModule, ButtonModule, CardModule],
+  imports: [CommonModule, FormsModule, ButtonModule, CardModule, InputTextModule],
   template: `
     <h1>Logs</h1>
     <div class="status" style="margin-top:8px;display:flex;align-items:center;gap:8px;">
@@ -20,7 +21,7 @@ import { ActivatedRoute } from '@angular/router';
     </div>
     <p-card class="mt-2 p-3">
       <div style="display:flex;gap:8px;margin-bottom:8px;">
-        <input [(ngModel)]="filter" placeholder="Filter"/>
+        <input pInputText [(ngModel)]="filter" placeholder="Filter"/>
         <p-button type="button" (onClick)="clear()" label="Clear"></p-button>
       </div>
       <pre #pane style="max-height:400px;overflow:auto;">{{ filtered.join('\n') }}</pre>

--- a/frontend/src/app/pages/risk.page.ts
+++ b/frontend/src/app/pages/risk.page.ts
@@ -30,9 +30,7 @@ import { ToastService } from '../shared/ui/toast.service';
       <ng-container *ngIf="!loadingPolicies">
         <form [formGroup]="policiesForm">
           <label>Risk policy
-            <select formControlName="policy">
-              <option *ngFor="let p of policies" [value]="p">{{ p }}</option>
-            </select>
+            <p-dropdown formControlName="policy" [options]="policies.map(p => ({label:p, value:p}))"></p-dropdown>
           </label>
         </form>
         <div class="muted" *ngIf="!policies.length">Политики не найдены</div>
@@ -48,28 +46,28 @@ import { ToastService } from '../shared/ui/toast.service';
         <div *ngIf="!loadingLimits">
           <div class="grid">
             <label>Max drawdown %
-              <input type="number" formControlName="max_drawdown_pct" />
+              <p-inputNumber formControlName="max_drawdown_pct"></p-inputNumber>
             </label>
             <label>DD window sec
-              <input type="number" formControlName="dd_window_sec" />
+              <p-inputNumber formControlName="dd_window_sec"></p-inputNumber>
             </label>
             <label>Stop duration sec
-              <input type="number" formControlName="stop_duration_sec" />
+              <p-inputNumber formControlName="stop_duration_sec"></p-inputNumber>
             </label>
             <label>Cooldown sec
-              <input type="number" formControlName="cooldown_sec" />
+              <p-inputNumber formControlName="cooldown_sec"></p-inputNumber>
             </label>
             <label>Min trades for DD
-              <input type="number" formControlName="min_trades_for_dd" />
+              <p-inputNumber formControlName="min_trades_for_dd"></p-inputNumber>
             </label>
             <label>Max base ratio
-              <input type="number" formControlName="max_base_ratio" />
+              <p-inputNumber formControlName="max_base_ratio"></p-inputNumber>
             </label>
             <label>Max loss %
-              <input type="number" formControlName="max_loss_pct" />
+              <p-inputNumber formControlName="max_loss_pct"></p-inputNumber>
             </label>
             <label>Max loss USD
-              <input type="number" formControlName="max_loss_usd" />
+              <p-inputNumber formControlName="max_loss_usd"></p-inputNumber>
             </label>
           </div>
           <p-button label="Сохранить" type="submit" [disabled]="loadingLimits" severity="primary"></p-button>

--- a/frontend/src/app/pages/strategies.component.ts
+++ b/frontend/src/app/pages/strategies.component.ts
@@ -11,12 +11,10 @@ import { MessageService } from 'primeng/api';
   imports: [CommonModule, FormsModule, PrimeNgModule],
   template: `
   <h2 class="mb-2">Strategies</h2>
-  <div class="mb-3">
-    <select [(ngModel)]="sid" class="border p-1 mr-2">
-      <option *ngFor="let s of strategies" [value]="s.id">{{ s.id }}</option>
-    </select>
-    <input [(ngModel)]="exchange" placeholder="exchange" class="border p-1 mr-2" />
-    <input [(ngModel)]="symbol" placeholder="symbol" class="border p-1 mr-2" />
+  <div class="mb-3 flex items-center gap-2">
+    <p-dropdown [options]="strategies" optionLabel="id" optionValue="id" [(ngModel)]="sid" class="mr-2"></p-dropdown>
+    <input pInputText [(ngModel)]="exchange" placeholder="exchange" class="mr-2" />
+    <input pInputText [(ngModel)]="symbol" placeholder="symbol" class="mr-2" />
     <p-button label="Start" (onClick)="start()"></p-button>
     <p-button label="Stop" (onClick)="stop()"></p-button>
   </div>


### PR DESCRIPTION
## Summary
- replace remaining HTML controls with PrimeNG components across app
- import PrimeNG modules for new widgets
- clean up theme toggle and forms to use PrimeNG

## Testing
- `npm run build` *(fails: Cannot find module '@primeuix/themes/aura', unresolved primeng modules)*

------
https://chatgpt.com/codex/tasks/task_e_68bbbc840a18832d8bd5b7369f0d5431