### PR TITLE
fix: restore CSV download button in strategy detail

### DIFF
--- a/frontend/src/app/features/strategy-detail/strategy-detail.component.ts
+++ b/frontend/src/app/features/strategy-detail/strategy-detail.component.ts
@@ -12,7 +12,13 @@ import { PrimeNgModule } from '../../prime-ng.module';
   <div class="p-4">
     <div class="flex items-center justify-between">
       <h2 class="text-xl font-semibold">Strategy: {{ sid }}</h2>
-      <p-button label="Download CSV" [link]="true" [href]="csvUrl()" target="_blank" severity="secondary"></p-button>
+      <a
+        pButton
+        label="Download CSV"
+        [href]="csvUrl()"
+        target="_blank"
+        severity="secondary"
+      ></a>
     </div>
     @if (error()) {
       <div class="mt-4 flex items-center gap-2">


### PR DESCRIPTION
## Summary
- replace the PrimeNG button wrapper with an anchor so the CSV download link works again

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_69013f5050a4832d9f5cd364590e74b1